### PR TITLE
Simulate underlying patch states

### DIFF
--- a/conditional_operation_control.py
+++ b/conditional_operation_control.py
@@ -16,16 +16,8 @@ class HasPauliEigenvalueOutcome():
 
 
 class EvaluationCondition:
-    def __init__(self, required_outcomes : List[Tuple[HasPauliEigenvalueOutcome,int]]):
-        self.required_outcomes = required_outcomes
-
     def does_evaluate(self):
-
-        for op_with_outcome, required_outcome in self.required_outcomes:
-            reference_outcome = op_with_outcome.get_outcome()
-            if reference_outcome is None or reference_outcome != required_outcome:
-                return False
-        return True
+        raise NotImplemented()
 
 
 

--- a/conditional_operation_control.py
+++ b/conditional_operation_control.py
@@ -2,6 +2,7 @@ from typing import *
 
 
 class HasPauliEigenvalueOutcome():
+    """Mixin class to be implmented by things that have a +1 or -1 outcome, like measurements of pauli products"""
     def get_outcome(self) -> Optional[int]:
         if hasattr(self,'outcome'):
             return self.outcome
@@ -12,17 +13,19 @@ class HasPauliEigenvalueOutcome():
         self.outcome = v
 
 
-
-
-
 class EvaluationCondition:
+    """Instances of this are used as functor to tell if something needs to be evaluated,
+    mostly together with EvaluationConditionManager"""
+    
     def does_evaluate(self):
         raise NotImplemented()
 
 
 
 class EvaluationConditionManager:
-
+    """ Mixin for objects representing operations conditional on outcomes. Uses instances EvaluationCondition
+    as functors to be called when checking if a condtional operation needs to execute or not"""
+    
     def set_condition(self, condition: EvaluationCondition):
         self.condition = condition
 

--- a/conditional_operation_control.py
+++ b/conditional_operation_control.py
@@ -1,0 +1,34 @@
+from typing import *
+
+
+class HasPauliEigenvalueOutcome():
+    def get_outcome(self) -> Optional[int]:
+        if hasattr(self,'outcome'):
+            return self.outcome
+
+    def set_outcome(self, v:int):
+        if v not in {-1,1}:
+            raise Exception("Pauli outcome must be -1 or +1, got: "+str(v))
+        self.outcome = v
+
+
+
+
+class EvaluationCondition:
+    def set_condition(self, outcome_op: HasPauliEigenvalueOutcome, outcome_for_evaluation: int):
+        self.outcome_op = outcome_op
+        self.outcome_for_evaluation = outcome_for_evaluation
+
+    def does_evaluate(self) -> bool:
+        """Note: Operations conditioned on outcomes that diddn't execute also won't execute"""
+        if not self.is_conditional():
+            return True
+
+        reference_outcome = self.outcome_op.get_outcome()
+        if reference_outcome is not None:
+            return reference_outcome == self.outcome_for_evaluation
+        return False
+
+    def is_conditional(self):
+        return hasattr(self,'outcome_op')
+

--- a/conditional_operation_control.py
+++ b/conditional_operation_control.py
@@ -14,21 +14,37 @@ class HasPauliEigenvalueOutcome():
 
 
 
+
 class EvaluationCondition:
-    def set_condition(self, outcome_op: HasPauliEigenvalueOutcome, outcome_for_evaluation: int):
-        self.outcome_op = outcome_op
-        self.outcome_for_evaluation = outcome_for_evaluation
+    def __init__(self, required_outcomes : List[Tuple[HasPauliEigenvalueOutcome,int]]):
+        self.required_outcomes = required_outcomes
+
+    def does_evaluate(self):
+
+        for op_with_outcome, required_outcome in self.required_outcomes:
+            reference_outcome = op_with_outcome.get_outcome()
+            if reference_outcome is None or reference_outcome != required_outcome:
+                return False
+        return True
+
+
+
+class EvaluationConditionManager:
+
+    def set_condition(self, condition: EvaluationCondition):
+        self.condition = condition
+
+    def get_condition(self) -> EvaluationCondition:
+        if self.is_conditional():
+            return self.condition
 
     def does_evaluate(self) -> bool:
         """Note: Operations conditioned on outcomes that diddn't execute also won't execute"""
         if not self.is_conditional():
             return True
 
-        reference_outcome = self.outcome_op.get_outcome()
-        if reference_outcome is not None:
-            return reference_outcome == self.outcome_for_evaluation
-        return False
+        return self.condition.does_evaluate()
 
     def is_conditional(self):
-        return hasattr(self,'outcome_op')
+        return hasattr(self,'condition') and self.condition is not None
 

--- a/debug/debug_qiskit_operator_flow.py
+++ b/debug/debug_qiskit_operator_flow.py
@@ -25,11 +25,10 @@ if __name__ == "__main__":
     print(c.render_ascii())
 
     logical_circuit = ls.LogicalLatticeComputation(c)
-    comp = ls.LatticeSurgeryComputation(logical_circuit,ls.LayoutType.SimplePreDistilledStates)
+    comp = ls.LatticeSurgeryComputation.make_computation_with_simulation(logical_circuit,ls.LayoutType.SimplePreDistilledStates)
     webgui.lattice_view.render_to_file(comp.composer.getSlices(), "../index.html")
 
     print(" ===== Slice states: =====")
 
-    sim = lssim.PatchSimulator(comp.composer.getSlices())
-    for sim_state in sim.intermediate_states:
-        print(sim_state)
+    for slice in comp.composer.getSlices():
+        print(slice.logical_state)

--- a/debug/debug_qiskit_operator_flow.py
+++ b/debug/debug_qiskit_operator_flow.py
@@ -1,5 +1,5 @@
-import pauli_rotations_to_lattice_surgery as ls
-from logical_patch_state_simulation import *
+import lattice_surgery_computation_composer as ls
+import logical_patch_state_simulation as lssim
 
 
 import webgui.lattice_view
@@ -24,11 +24,12 @@ if __name__ == "__main__":
     c.add_pauli_block(ls.Rotation.from_list([ls_Z, ls_Z], Fraction(1, 4)))
     print(c.render_ascii())
 
-    comp = ls.pauli_rotation_to_lattice_surgery_computation(c)
+    logical_circuit = ls.LogicalLatticeComputation(c)
+    comp = ls.LatticeSurgeryComputation(logical_circuit,ls.LayoutType.SimplePreDistilledStates)
     webgui.lattice_view.render_to_file(comp.composer.getSlices(), "../index.html")
 
     print(" ===== Slice states: =====")
 
-    sim_states = simulate_slices(comp.composer.getSlices())
-    for sim_state in sim_states:
+    sim = lssim.PatchSimulator(comp.composer.getSlices())
+    for sim_state in sim.intermediate_states:
         print(sim_state)

--- a/debug/debug_state_separator.py
+++ b/debug/debug_state_separator.py
@@ -1,0 +1,45 @@
+import sys
+from typing import *
+
+import lattice_surgery_computation_composer as ls
+import logical_patch_state_simulation as lssim
+
+
+import webgui.lattice_view
+from fractions import Fraction
+
+import qiskit.aqua.operators as qk
+import qiskit.quantum_info as qkinfo
+
+import math
+
+
+
+if __name__ == "__main__":
+    if len(sys.argv)>1 and sys.argv[1] == 'debug_trace':
+        state = qk.DictStateFn({'10': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
+        l = [lssim.StateSeparator.trace_dict_state(state,[0]),lssim.StateSeparator.trace_dict_state(state,[1])]
+        print(l[0])
+        print(l[1])
+
+
+    print("Separable qubits,")
+    bell_pair = qk.DictStateFn({'11':1/math.sqrt(2),'00':1/math.sqrt(2)})
+    print("of a Bell pair:",lssim.StateSeparator.get_separable_qubits(bell_pair))
+    bell_pair_plus = qk.Plus^bell_pair
+    bell_pair_plus = cast(qk.DictStateFn, bell_pair_plus.eval())
+    print("of a Bell pair tensored with |+>:",lssim.StateSeparator.get_separable_qubits(bell_pair_plus))
+    bell_pair_plus_surround = qk.Minus ^ bell_pair ^ qk.Plus
+    bell_pair_plus_surround = cast(qk.DictStateFn, bell_pair_plus_surround.eval())
+    print("of |+> otimes Bell pair otimes |->:")
+    separated = lssim.StateSeparator.get_separable_qubits(bell_pair_plus_surround)
+    print("0 :", separated[0])
+    print("3 :", separated[3])
+    print()
+
+    print("More tests:")
+    state = qk.DictStateFn({'10': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
+    print(lssim.StateSeparator.get_separable_qubits(state))
+
+    state = qk.DictStateFn({'000':1/math.sqrt(4),'010':1/math.sqrt(4), '100':1/math.sqrt(4),'110':1/math.sqrt(4)})
+    print(lssim.StateSeparator.get_separable_qubits(state))

--- a/debug/debug_state_separator.py
+++ b/debug/debug_state_separator.py
@@ -4,6 +4,7 @@ from typing import *
 import lattice_surgery_computation_composer as ls
 import logical_patch_state_simulation as lssim
 
+from qiskit_opflow_utils import StateSeparator
 
 import webgui.lattice_view
 from fractions import Fraction
@@ -18,28 +19,28 @@ import math
 if __name__ == "__main__":
     if len(sys.argv)>1 and sys.argv[1] == 'debug_trace':
         state = qk.DictStateFn({'10': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
-        l = [lssim.StateSeparator.trace_dict_state(state,[0]),lssim.StateSeparator.trace_dict_state(state,[1])]
+        l = [StateSeparator.trace_dict_state(state,[0]),StateSeparator.trace_dict_state(state,[1])]
         print(l[0])
         print(l[1])
 
 
     print("Separable qubits,")
     bell_pair = qk.DictStateFn({'11':1/math.sqrt(2),'00':1/math.sqrt(2)})
-    print("of a Bell pair:",lssim.StateSeparator.get_separable_qubits(bell_pair))
+    print("of a Bell pair:",StateSeparator.get_separable_qubits(bell_pair))
     bell_pair_plus = qk.Plus^bell_pair
     bell_pair_plus = cast(qk.DictStateFn, bell_pair_plus.eval())
-    print("of a Bell pair tensored with |+>:",lssim.StateSeparator.get_separable_qubits(bell_pair_plus))
+    print("of a Bell pair tensored with |+>:",StateSeparator.get_separable_qubits(bell_pair_plus))
     bell_pair_plus_surround = qk.Minus ^ bell_pair ^ qk.Plus
     bell_pair_plus_surround = cast(qk.DictStateFn, bell_pair_plus_surround.eval())
     print("of |+> otimes Bell pair otimes |->:")
-    separated = lssim.StateSeparator.get_separable_qubits(bell_pair_plus_surround)
+    separated = StateSeparator.get_separable_qubits(bell_pair_plus_surround)
     print("0 :", separated[0])
     print("3 :", separated[3])
     print()
 
     print("More tests:")
     state = qk.DictStateFn({'10': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
-    print(lssim.StateSeparator.get_separable_qubits(state))
+    print(StateSeparator.get_separable_qubits(state))
 
     state = qk.DictStateFn({'000':1/math.sqrt(4),'010':1/math.sqrt(4), '100':1/math.sqrt(4),'110':1/math.sqrt(4)})
-    print(lssim.StateSeparator.get_separable_qubits(state))
+    print(StateSeparator.get_separable_qubits(state))

--- a/lattice_surgery_computation_composer.py
+++ b/lattice_surgery_computation_composer.py
@@ -114,8 +114,6 @@ class LatticeSurgeryComputation:
         self.composer.lattice().min_cols = 2*self.num_qubits
         self.composer.lattice().min_rows = 3
 
-        # self._import_logical_computation()
-
     @staticmethod
     def make_computation_with_simulation(logical_computation: LogicalLatticeComputation, layout_type: LayoutType):
         comp = LatticeSurgeryComputation(logical_computation,layout_type)
@@ -141,15 +139,6 @@ class LatticeSurgeryComputation:
             self.logical_qubits.append(cell)
             self.composer.lattice().getPatchOfCell(cell).set_uuid(quuid)
 
-    def _import_logical_computation(self):
-
-        # Give a blank slice to show the layout
-        with self.timestep() as blank_slice: pass
-
-        for logical_op in self.logical_computation.ops:
-            with self.timestep() as slice:
-                slice.addLogicalOperation(logical_op)
-        return self
 
     def _init_simple_magic_state_array(self, num_magic_states: int): # TODO move this to layout initializer
         start_magic_state_array = self.composer.lattice().getCols()

--- a/logical_lattice_ops.py
+++ b/logical_lattice_ops.py
@@ -10,14 +10,15 @@ from circuit import *
 
 """Patches are now identified by uuids"""
 
-class LogicalLatticeOperation:
+
+class LogicalLatticeOperation(EvaluationCondition):
+
     def get_operating_patches(self) -> List[uuid.UUID]:
         raise NotImplemented()
 
 
 
-
-class SinglePatchMeasurement(LogicalLatticeOperation):
+class SinglePatchMeasurement(LogicalLatticeOperation,HasPauliEigenvalueOutcome):
     def __init__(self, qubit_uuid: uuid.UUID, op: PauliOperator):
         self.qubit_uuid = qubit_uuid
         self.op = op
@@ -26,7 +27,7 @@ class SinglePatchMeasurement(LogicalLatticeOperation):
         return [self.qubit_uuid]
 
 
-class MultiBodyMeasurement(LogicalLatticeOperation):
+class MultiBodyMeasurement(LogicalLatticeOperation,HasPauliEigenvalueOutcome):
     def __init__(self, patch_pauli_operator_map: Dict[uuid.UUID, PauliOperator]):
         self.patch_pauli_operator_map = patch_pauli_operator_map
 

--- a/logical_lattice_ops.py
+++ b/logical_lattice_ops.py
@@ -143,7 +143,7 @@ class RotationsComposer:
         """See Figure 11 of Litinski's GoSC
         """
         ancilla_uuid = uuid.uuid4()
-        ancilla_initialization = AncillaQubitPatchInitialization(SymbolicState("|Y>"), ancilla_uuid)
+        ancilla_initialization = AncillaQubitPatchInitialization(InitializeableState.YEigenState, ancilla_uuid)
 
         multi_body_measurement = MultiBodyMeasurement({})
         multi_body_measurement.patch_pauli_operator_map[ancilla_uuid] = PauliOperator.Z

--- a/logical_lattice_ops.py
+++ b/logical_lattice_ops.py
@@ -186,3 +186,4 @@ class RotationsComposer:
                 SinglePatchMeasurement(magic_state_uuid, PauliOperator.X),
                 second_corrective_rotation]
 
+

--- a/logical_patch_state_simulation.py
+++ b/logical_patch_state_simulation.py
@@ -3,6 +3,9 @@ import random
 from patches import *
 
 import qiskit.aqua.operators as qk
+import qiskit.quantum_info as qkinfo
+import qiskit.exceptions as qkexcept
+import numpy.linalg
 
 from typing import *
 import math
@@ -202,4 +205,46 @@ class PatchSimulator:
 
 
 
+
+class StateSeparator:
+
+    @staticmethod
+    def trace_dict_state(state: qk.DictStateFn, trace_over: List[int]) -> qk.DictStateFn:
+        """Assumes state is separable as a DictStateFn can only represent pure states"""
+        input_statevector = qkinfo.Statevector(state.to_matrix())
+        traced_statevector = qkinfo.partial_trace(input_statevector, trace_over).to_statevector()
+        return qk.DictStateFn(traced_statevector.to_dict())
+
+    @staticmethod
+    def trace_to_density_op(state: qk.DictStateFn, trace_over: List[int]) -> qkinfo.DensityMatrix:
+        input_statevector = qkinfo.Statevector(state.to_matrix())
+        return qkinfo.partial_trace(input_statevector, trace_over)
+
+    @staticmethod
+    def separate(qnum:int, dict_state : qk.DictStateFn) -> Optional[qk.DictStateFn]:
+        """The closer to zero the closer to being separable"""
+
+        # Qubits are indexed left to right in the dict state so we need to swap
+        remaing_qubits = list(range(dict_state.num_qubits))
+        remaing_qubits.remove(qnum)
+
+        selected_qubit_maybe_mixed_state = StateSeparator.trace_to_density_op(dict_state, remaing_qubits)
+
+        try:
+            selected_qubit_pure_state = selected_qubit_maybe_mixed_state.to_statevector(rtol=10**(-10))
+            return qk.DictStateFn(selected_qubit_pure_state.to_dict())
+
+        except qkexcept.QiskitError as e:
+            if e.message != 'Density matrix is not a pure state':  raise e
+            return None
+
+
+    @staticmethod
+    def get_separable_qubits(dict_state : qk.DictStateFn) -> Dict[int,qk.DictStateFn]:
+        out = {}
+        for i in range(dict_state.num_qubits):
+            maybe_state = StateSeparator.separate(i, dict_state)
+            if maybe_state is not None:
+                out[i] = maybe_state
+        return out
 

--- a/logical_patch_state_simulation.py
+++ b/logical_patch_state_simulation.py
@@ -3,9 +3,7 @@ import random
 from patches import *
 
 import qiskit.aqua.operators as qk
-import qiskit.quantum_info as qkinfo
-import qiskit.exceptions as qkexcept
-import numpy.linalg
+
 
 from typing import *
 import math
@@ -206,45 +204,5 @@ class PatchSimulator:
 
 
 
-class StateSeparator:
 
-    @staticmethod
-    def trace_dict_state(state: qk.DictStateFn, trace_over: List[int]) -> qk.DictStateFn:
-        """Assumes state is separable as a DictStateFn can only represent pure states"""
-        input_statevector = qkinfo.Statevector(state.to_matrix())
-        traced_statevector = qkinfo.partial_trace(input_statevector, trace_over).to_statevector()
-        return qk.DictStateFn(traced_statevector.to_dict())
-
-    @staticmethod
-    def trace_to_density_op(state: qk.DictStateFn, trace_over: List[int]) -> qkinfo.DensityMatrix:
-        input_statevector = qkinfo.Statevector(state.to_matrix())
-        return qkinfo.partial_trace(input_statevector, trace_over)
-
-    @staticmethod
-    def separate(qnum:int, dict_state : qk.DictStateFn) -> Optional[qk.DictStateFn]:
-        """The closer to zero the closer to being separable"""
-
-        # Qubits are indexed left to right in the dict state so we need to swap
-        remaing_qubits = list(range(dict_state.num_qubits))
-        remaing_qubits.remove(qnum)
-
-        selected_qubit_maybe_mixed_state = StateSeparator.trace_to_density_op(dict_state, remaing_qubits)
-
-        try:
-            selected_qubit_pure_state = selected_qubit_maybe_mixed_state.to_statevector(rtol=10**(-10))
-            return qk.DictStateFn(selected_qubit_pure_state.to_dict())
-
-        except qkexcept.QiskitError as e:
-            if e.message != 'Density matrix is not a pure state':  raise e
-            return None
-
-
-    @staticmethod
-    def get_separable_qubits(dict_state : qk.DictStateFn) -> Dict[int,qk.DictStateFn]:
-        out = {}
-        for i in range(dict_state.num_qubits):
-            maybe_state = StateSeparator.separate(i, dict_state)
-            if maybe_state is not None:
-                out[i] = maybe_state
-        return out
 

--- a/logical_patch_state_simulation.py
+++ b/logical_patch_state_simulation.py
@@ -1,9 +1,39 @@
+import random
+
 from patches import *
 
 import qiskit.aqua.operators as qk
 
 from typing import *
 import math
+import cmath
+import uuid
+
+
+class ConvertersToQiskit:
+    @staticmethod
+    def pauli_op(op: PauliOperator) -> Optional[qiskit.aqua.operators.PrimitiveOp]:
+        known_map: Dict[PauliOperator, qiskit.aqua.operators.PrimitiveOp] = {
+            PauliOperator.I: qiskit.aqua.operators.I,
+            PauliOperator.X: qiskit.aqua.operators.X,
+            PauliOperator.Y: qiskit.aqua.operators.Y,
+            PauliOperator.Z: qiskit.aqua.operators.Z
+        }
+        return known_map[op]
+
+
+    @staticmethod
+    def symbolic_state(s:SymbolicState)->qk.StateFn:
+        if s == InitializeableState.Zero:
+            return qk.Zero
+        elif s == InitializeableState.Plus:
+            return qk.One
+        elif s == InitializeableState.YEigenState:
+            return (qk.Zero - 1j*qk.One)/math.sqrt(2)
+        elif s == InitializeableState.Magic:
+            return (qk.Zero + cmath.exp(1j*math.pi/4)*qk.One)/math.sqrt(2)
+        else:
+            raise Exception("State cannot be converted to qiskit: "+repr(s))
 
 
 def circuit_add_op_to_qubit(circ : qk.CircuitOp, op: qk.PrimitiveOp, idx: int) -> qk.CircuitOp:
@@ -45,17 +75,22 @@ class ProjectiveMeasurement:
 
         @staticmethod
         def pauli_product_measurement_distribution(pauli_observable: qk.OperatorBase, state: qk.OperatorBase) \
-                -> Tuple[Tuple[qk.OperatorBase, float], Tuple[qk.OperatorBase, float]] :
+                -> List[Tuple[qk.OperatorBase, float]] :
             p1, p2 = ProjectiveMeasurement.get_projectors_from_pauli_observable(pauli_observable)
-            appl1, appl2 = ProjectiveMeasurement.apply_projectors([p1, p2], state)
-            return appl1, appl2 # Unpacked for typing
+            return ProjectiveMeasurement.apply_projectors([p1, p2], state)
 
+
+T = TypeVar('T')
+def proportional_choice(assoc_data_prob : List[Tuple[T, float]]) -> T:
+    return random.choices([val for val, prob in assoc_data_prob],
+                          weights=[prob for val, prob in assoc_data_prob],
+                          k=1)
 
 class PatchToQubitMapper:
     def __init__(self, slices: List[Lattice]):
-        self.patch_location_to_logical_idx: Dict[Union[Tuple[int, int], uuid.UUID], int] = dict()
+        self.patch_location_to_logical_idx: Dict[uuid.UUID, int] = dict()
         for slice in slices:
-            self.__add_patches_from_slice(slice)
+            self._add_patches_from_slice(slice)
 
     def get_idx(self, patch: uuid.UUID) -> int:
         return self.patch_location_to_logical_idx[patch]
@@ -63,13 +98,22 @@ class PatchToQubitMapper:
     def max_num_patches(self) ->int:
         return len(self.patch_location_to_logical_idx)
 
-    def __add_patches_from_slice(self, lattice: Lattice):
-        for p in PatchToQubitMapper.__get_operating_patches(lattice.logical_ops):
+    def get_uuid(self, target_idx: int) -> uuid.UUID:
+        for quiid, idx in self.patch_location_to_logical_idx.items():
+            if idx==target_idx:
+                return quiid
+
+    def enumerate_patches_by_index(self) -> Iterable[Tuple[int, uuid.UUID]]:
+        for idx in range(self.max_num_patches()):
+            yield (idx, self.get_uuid(idx))
+
+    def _add_patches_from_slice(self, lattice: Lattice):
+        for p in PatchToQubitMapper._get_all_operating_patches(lattice.logical_ops):
             if self.patch_location_to_logical_idx.get(p) is None:
                 self.patch_location_to_logical_idx[p] = self.max_num_patches()
 
     @staticmethod
-    def __get_operating_patches(logical_ops: List[LogicalLatticeOperation]) -> List[Union[Tuple[int, int], uuid.UUID]]:
+    def _get_all_operating_patches(logical_ops: List[LogicalLatticeOperation]) -> List[uuid.UUID]:
         patch_set = set()
         for op in logical_ops:
             patch_set = patch_set.union(op.get_operating_patches())
@@ -77,19 +121,49 @@ class PatchToQubitMapper:
 
 
 
+def tensor_list(l):
+    t = l[0]
+    for s in l[1:]:
+        t = t ^ s
+    return t
+
 
 class PatchSimulator:
     def __init__(self, slices: List[Lattice]):
         self.slices = slices
+        self.mapper = PatchToQubitMapper(self.slices)
+        self.intermediate_states: List[List[qk.StateFn]] = self._simulate_patch_operations(self.slices)
 
-    def run(self):
-        self.simulate_slices(self.slices)
 
-    def simulate_slices(self, slices: List[Lattice]) -> List[List[qk.DictStateFn]]:
+    def _make_initial_logical_state(self):
+        """Every patch, when initialized, is considered a new logical qubit.
+        So all patch initializations and magic state requests are handled ahead of time"""
+        initial_ancilla_states:Dict[uuid.UUID,SymbolicState] = dict()
+
+        def add_initial_ancilla_state(quuid, symbolic_state):
+            if initial_ancilla_states.get(quuid) is not None:
+                raise Exception("Initializing patch "+str(quuid)+" twice")
+            initial_ancilla_states[quuid] = symbolic_state
+
+        def get_init_state(quuid:uuid.UUID) -> qk.StateFn:
+            return ConvertersToQiskit.symbolic_state(initial_ancilla_states.get(quuid, InitializeableState.Zero))
+
+        for slice in self.slices:
+            for op in slice.logical_ops:
+                if isinstance(op, AncillaQubitPatchInitialization):
+                    add_initial_ancilla_state(op.qubit_uuid,op.qubit_state)
+                elif isinstance(op, MagicStateRequest):
+                    add_initial_ancilla_state(op.qubit_uuid,InitializeableState.Magic)
+
+        d = list(self.mapper.enumerate_patches_by_index())
+        all_init_states = [get_init_state(quuid) for idx, quuid in self.mapper.enumerate_patches_by_index()]
+        return tensor_list(all_init_states)
+
+    def _simulate_patch_operations(self, slices: List[Lattice]) -> List[List[qk.DictStateFn]]:
         """Returns a list of computation states"""
         mapper = PatchToQubitMapper(slices)
-        logical_state = qk.Zero ^ mapper.max_num_patches()
-        per_slice_intermediate_logical_states: List[List[qk.OperatorBase]] = [[logical_state]]
+        logical_state = self._make_initial_logical_state()
+        per_slice_intermediate_logical_states: List[List[qk.DictStateFn]] = [[logical_state]]
 
 
         for slice_num, slice in enumerate(slices):
@@ -99,19 +173,29 @@ class PatchSimulator:
 
                 if isinstance(current_op, SinglePatchMeasurement):
                     measure_idx = mapper.get_idx(current_op.qubit_uuid)
-                    local_observable = lattice_surgery_op_to_quiskit_op(current_op.op)
+                    local_observable = ConvertersToQiskit.pauli_op(current_op.op)
                     global_observable = (qk.I ^ measure_idx) ^ local_observable ^ (
                                 qk.I ^ (mapper.max_num_patches() - measure_idx - 1))
-                    logical_state = ProjectiveMeasurement.pauli_product_measurement_distribution(global_observable, logical_state)
-                # elif isinstance(current_op, AncillaQubitPatchInitialization):
-                # TODO init ahead of time
+                    distribution = ProjectiveMeasurement.pauli_product_measurement_distribution(global_observable,
+                                                                                                 logical_state)
+                    logical_state = proportional_choice(distribution)
 
                 elif isinstance(current_op, PauliOperator):
                     for patch, op in current_op.patch_pauli_operator_map.items():
-                        logical_state = circuit_add_op_to_qubit(logical_state, lattice_surgery_op_to_quiskit_op(op),
+                        logical_state = circuit_add_op_to_qubit(logical_state, ConvertersToQiskit.pauli_op(op),
                                                                 mapper.get_idx(patch))
                         logical_state = logical_state.eval()  # Convert to DictStateFn
-                # elif isinstance(current_op, MultiBodyMeasurement):
+
+                elif isinstance(current_op, MultiBodyMeasurement):
+                    pauli_op_list : List[qk.PrimitiveOp] = []
+
+                    for j,quuid in self.mapper.enumerate_patches_by_index():
+                        pauli_op_list.append(current_op.patch_pauli_operator_map.get(quuid, PauliOperator.I))
+                    global_observable = tensor_list(list(map(ConvertersToQiskit.pauli_op,pauli_op_list)))
+                    distribution = ProjectiveMeasurement.pauli_product_measurement_distribution(global_observable,
+                                                                                                 logical_state)
+                    logical_state = proportional_choice(distribution)
+
 
                 per_slice_intermediate_logical_states[-1].append(logical_state)
 

--- a/logical_patch_state_simulation.py
+++ b/logical_patch_state_simulation.py
@@ -84,7 +84,7 @@ T = TypeVar('T')
 def proportional_choice(assoc_data_prob : List[Tuple[T, float]]) -> T:
     return random.choices([val for val, prob in assoc_data_prob],
                           weights=[prob for val, prob in assoc_data_prob],
-                          k=1)
+                          k=1)[0]
 
 class PatchToQubitMapper:
     def __init__(self, slices: List[Lattice]):
@@ -177,8 +177,8 @@ class PatchSimulator:
                     global_observable = (qk.I ^ measure_idx) ^ local_observable ^ (
                                 qk.I ^ (mapper.max_num_patches() - measure_idx - 1))
                     distribution = ProjectiveMeasurement.pauli_product_measurement_distribution(global_observable,
-                                                                                                 logical_state)
-                    logical_state = proportional_choice(distribution)
+                                                                                                    logical_state)
+                    logical_state = proportional_choice(distribution).eval()
 
                 elif isinstance(current_op, PauliOperator):
                     for patch, op in current_op.patch_pauli_operator_map.items():
@@ -194,7 +194,7 @@ class PatchSimulator:
                     global_observable = tensor_list(list(map(ConvertersToQiskit.pauli_op,pauli_op_list)))
                     distribution = ProjectiveMeasurement.pauli_product_measurement_distribution(global_observable,
                                                                                                  logical_state)
-                    logical_state = proportional_choice(distribution)
+                    logical_state = proportional_choice(distribution).eval()
 
 
                 per_slice_intermediate_logical_states[-1].append(logical_state)

--- a/patches.py
+++ b/patches.py
@@ -4,6 +4,7 @@ from rotation import *
 import itertools
 from qubit_state import *
 from logical_lattice_ops import *
+import qiskit.aqua.operators as qk
 
 import uuid
 
@@ -120,6 +121,7 @@ class Lattice:
         self.min_rows = min_rows
         self.min_cols = min_cols
         self.logical_ops : List[LogicalLatticeOperation] = []
+        self.logical_state : Optional[qk.DictStateFn] = None
 
     def getMaxCoord(self, coord_type: CoordType)->int:
         all_coords = itertools.chain.from_iterable(map(lambda patch: patch.getCoordList(coord_type), self.patches))

--- a/qiskit_opflow_utils.py
+++ b/qiskit_opflow_utils.py
@@ -7,22 +7,40 @@ from typing import *
 
 
 class StateSeparator:
-
+    """Namespace for functions that deal with separating states."""
+    
     @staticmethod
     def trace_dict_state(state: qk.DictStateFn, trace_over: List[int]) -> qk.DictStateFn:
-        """Assumes state is separable as a DictStateFn can only represent pure states"""
+        """
+        Take a state comprised on n qubits and get the trace of the system over the subsystems
+        specified by a list of indices.
+        
+        Assumes state is separable as a DictStateFn can only represent pure states.
+        """
         input_statevector = qkinfo.Statevector(state.to_matrix())
         traced_statevector = qkinfo.partial_trace(input_statevector, trace_over).to_statevector()
         return qk.DictStateFn(traced_statevector.to_dict())
 
     @staticmethod
     def trace_to_density_op(state: qk.DictStateFn, trace_over: List[int]) -> qkinfo.DensityMatrix:
+        """
+        Take a state comprised on n qubits and get the trace of the system over the subsystems
+        specified by a list of indices.
+        
+        Makes no assumption about the separability of the traced subsystems and gives a density
+        matrix as a result.
+        """
         input_statevector = qkinfo.Statevector(state.to_matrix())
         return qkinfo.partial_trace(input_statevector, trace_over)
 
     @staticmethod
     def separate(qnum:int, dict_state : qk.DictStateFn) -> Optional[qk.DictStateFn]:
-        """The closer to zero the closer to being separable"""
+        """
+        When a qubit is not entangled (up to a small tolerance) with the rest of the register,
+        trace over the rest of the system, giving the qubits' pure state.
+
+        If the selected qubit is entangled return None.
+        """
 
         # Qubits are indexed left to right in the dict state so we need to swap
         remaing_qubits = list(range(dict_state.num_qubits))
@@ -41,6 +59,12 @@ class StateSeparator:
 
     @staticmethod
     def get_separable_qubits(dict_state : qk.DictStateFn) -> Dict[int,qk.DictStateFn]:
+        """
+        For each qubit, numerically detect if it's seprabale or not. If it is, add to
+        the result dict, indexed by subsystem, the state traced over the remaining qubits.
+
+        I.e. if a qubit is not entangled with the rest, its state shows up in the result. 
+        """
         out = {}
         for i in range(dict_state.num_qubits):
             maybe_state = StateSeparator.separate(i, dict_state)

--- a/qiskit_opflow_utils.py
+++ b/qiskit_opflow_utils.py
@@ -1,0 +1,49 @@
+import qiskit.aqua.operators as qk
+import qiskit.quantum_info as qkinfo
+import qiskit.exceptions as qkexcept
+import numpy.linalg
+
+from typing import *
+
+
+class StateSeparator:
+
+    @staticmethod
+    def trace_dict_state(state: qk.DictStateFn, trace_over: List[int]) -> qk.DictStateFn:
+        """Assumes state is separable as a DictStateFn can only represent pure states"""
+        input_statevector = qkinfo.Statevector(state.to_matrix())
+        traced_statevector = qkinfo.partial_trace(input_statevector, trace_over).to_statevector()
+        return qk.DictStateFn(traced_statevector.to_dict())
+
+    @staticmethod
+    def trace_to_density_op(state: qk.DictStateFn, trace_over: List[int]) -> qkinfo.DensityMatrix:
+        input_statevector = qkinfo.Statevector(state.to_matrix())
+        return qkinfo.partial_trace(input_statevector, trace_over)
+
+    @staticmethod
+    def separate(qnum:int, dict_state : qk.DictStateFn) -> Optional[qk.DictStateFn]:
+        """The closer to zero the closer to being separable"""
+
+        # Qubits are indexed left to right in the dict state so we need to swap
+        remaing_qubits = list(range(dict_state.num_qubits))
+        remaing_qubits.remove(qnum)
+
+        selected_qubit_maybe_mixed_state = StateSeparator.trace_to_density_op(dict_state, remaing_qubits)
+
+        try:
+            selected_qubit_pure_state = selected_qubit_maybe_mixed_state.to_statevector(rtol=10**(-10))
+            return qk.DictStateFn(selected_qubit_pure_state.to_dict())
+
+        except qkexcept.QiskitError as e:
+            if e.message != 'Density matrix is not a pure state':  raise e
+            return None
+
+
+    @staticmethod
+    def get_separable_qubits(dict_state : qk.DictStateFn) -> Dict[int,qk.DictStateFn]:
+        out = {}
+        for i in range(dict_state.num_qubits):
+            maybe_state = StateSeparator.separate(i, dict_state)
+            if maybe_state is not None:
+                out[i] = maybe_state
+        return out

--- a/qubit_state.py
+++ b/qubit_state.py
@@ -60,6 +60,7 @@ class InitializeableState(SymbolicState):
 
     Zero = SymbolicState('|0>')
     Plus = SymbolicState('|+>')
+    YEigenState = SymbolicState('|Y>')
     UnknownState = SymbolicState('|?>')
     Magic = SymbolicState('|m>') # magic state (|0>+e^(pi*i/4)|1>)/sqrt(2)
 

--- a/rotation.py
+++ b/rotation.py
@@ -56,16 +56,6 @@ class PauliOperator(Enum):
             return PauliOperator.X
 
 
-def lattice_surgery_op_to_quiskit_op( op :PauliOperator) -> Optional[qiskit.aqua.operators.PrimitiveOp]:
-    known_map : Dict[PauliOperator, qiskit.aqua.operators.PrimitiveOp] = {
-        PauliOperator.I : qiskit.aqua.operators.I,
-        PauliOperator.X : qiskit.aqua.operators.X,
-        PauliOperator.Y : qiskit.aqua.operators.Y,
-        PauliOperator.Z : qiskit.aqua.operators.Z
-    }
-    return known_map[op]
-
-
 class PauliProductOperation(object):
 
     qubit_num:  int = None

--- a/rotation.py
+++ b/rotation.py
@@ -1,4 +1,4 @@
-import numpy as np
+from conditional_operation_control import *
 from typing import *
 from enum import Enum
 from fractions import Fraction
@@ -56,7 +56,7 @@ class PauliOperator(Enum):
             return PauliOperator.X
 
 
-class PauliProductOperation(object):
+class PauliProductOperation(EvaluationCondition):
 
     qubit_num:  int = None
     ops_list:   List[PauliOperator] = None

--- a/rotation.py
+++ b/rotation.py
@@ -56,7 +56,7 @@ class PauliOperator(Enum):
             return PauliOperator.X
 
 
-class PauliProductOperation(EvaluationCondition):
+class PauliProductOperation(EvaluationConditionManager):
 
     qubit_num:  int = None
     ops_list:   List[PauliOperator] = None


### PR DESCRIPTION
Can track the state of the logical computation in of `qiskit.aqua.operators.DictStateFn`. So the computation is represented as one big quantum register that evolves with the slices. That is for each slice there is one `DictStateFn` object representing the state of the system.

The simulation happens in parallel with state generation, which makes conditional corrective not to appear on the lattice when they are not required by the previous measurement outcomes. This is the only visible impact of simulation on the UI.

closes #40 