### PR TITLE
Refactor symbolic state handling + Misc fixes

### DIFF
--- a/ancilla_patch_routing.py
+++ b/ancilla_patch_routing.py
@@ -53,7 +53,7 @@ def add_directed_edges(
         lattice: patches.Lattice,
         patch_pauli_operator_map: Dict[Tuple[int, int], patches.PauliOperator],
         source_patch_vertex: str,
-        tagret_patch_vertex: str
+        tagret_patch_vertex: List[str]
     ):
 
     for j, patch in enumerate(lattice.patches):

--- a/debug/debug_pi_over_eight_routing.py
+++ b/debug/debug_pi_over_eight_routing.py
@@ -1,0 +1,20 @@
+from lattice_surgery_computation_composer import *
+from webgui import lattice_view
+from debug.util import *
+
+if __name__ == "__main__":
+    c = Circuit(4)
+    I = PauliOperator.I
+    X = PauliOperator.X
+    Y = PauliOperator.Y
+    Z = PauliOperator.Z
+
+    c.add_pauli_block(Rotation.from_list(    [I, X, I, I], Fraction(1, 8)))
+    c.add_pauli_block(Rotation.from_list(    [I, I, Z, X], Fraction(1, 8)))
+
+    print(c.render_ascii())
+
+    logical_comp = LogicalLatticeComputation(c)
+
+    lsc = LatticeSurgeryComputation.make_computation_with_simulation(logical_comp, LayoutType.SimplePreDistilledStates)
+    lattice_view.render_to_file(lsc.composer.getSlices(), "index.html", template="/home/george/courses/CMPT415_498/code/lattice-surgery-compiler/webgui/templates/lattice_view.mak")

--- a/lattice_surgery_computation_composer.py
+++ b/lattice_surgery_computation_composer.py
@@ -333,8 +333,10 @@ class LatticeSurgeryComputationComposer:
                 idx = sim.mapper.get_idx(patch.patch_uuid)
                 if separable_states.get(idx) is not None:
                     alpha, beta = separable_states[idx].to_matrix()
-                    if isinstance(patch.state, SymbolicState):
-                        patch.state = DefaultSymbolicStates.from_amplitudes(alpha, beta)
-                    elif isinstance(patch.state, ActiveState):
+                    if isinstance(patch.state, ActiveState):
                         patch.state.next = DefaultSymbolicStates.from_amplitudes(alpha, beta)
+                    else:
+                        patch.state = DefaultSymbolicStates.from_amplitudes(alpha, beta)
+                else:
+                    patch.state = EntangledState()
 

--- a/lattice_surgery_computation_composer.py
+++ b/lattice_surgery_computation_composer.py
@@ -39,6 +39,17 @@ class LayoutInitializer:
         ])
 
     @staticmethod
+    def rotatedSingleSquarePatch(cell:Tuple[int,int],
+                          patch_type:patches.PatchType = patches.PatchType.Qubit,
+                          patch_state:patches.QubitState = patches.DefalutSymbolicStates.Zero):
+        return patches.Patch(patch_type, patch_state, [cell],[
+            patches.Edge(patches.EdgeType.Solid,  cell, patches.Orientation.Top),
+            patches.Edge(patches.EdgeType.Solid,  cell, patches.Orientation.Bottom),
+            patches.Edge(patches.EdgeType.Dashed,  cell, patches.Orientation.Left),
+            patches.Edge(patches.EdgeType.Dashed,  cell, patches.Orientation.Right)
+        ])
+
+    @staticmethod
     def simpleRightFacingDistillery(top_left_corner: Tuple[int,int]) -> List[patches.Patch]:
         # Requires
         x,y = top_left_corner
@@ -111,10 +122,10 @@ class LatticeSurgeryComputation:
         self._initialize_layout(SimplePreDistilledStatesLayoutInitializer(self.num_qubits))
 
         self.ancilla_locations = [(j,2) for j in range(self.num_qubits)]
-        self._init_simple_magic_state_array(self.logical_computation.count_magic_states())
-
-        self.composer.lattice().min_cols = 2*self.num_qubits
+        self.composer.lattice().min_cols = 2 * self.num_qubits
         self.composer.lattice().min_rows = 3
+
+        self._init_simple_magic_state_array(self.logical_computation.count_magic_states())
 
     @staticmethod
     def make_computation_with_simulation(logical_computation: LogicalLatticeComputation, layout_type: LayoutType):
@@ -150,14 +161,14 @@ class LatticeSurgeryComputation:
         start_magic_state_array = self.composer.lattice().getCols()
         self.magic_state_queue:List[Tuple[int,int]] = []
         for j in range(start_magic_state_array, start_magic_state_array + num_magic_states):
-            magic_state_pos = (j, 0)
-            self.composer.lattice().patches.append(LayoutInitializer.singleSquarePatch(
+            magic_state_pos = (j+1, 0)
+            self.composer.lattice().patches.append(LayoutInitializer.rotatedSingleSquarePatch(
                 magic_state_pos,
                 patches.PatchType.DistillationQubit,
                 patches.DefaultSymbolicStates.Magic))
             self.magic_state_queue.append(magic_state_pos)
 
-        self.composer.lattice().min_cols += num_magic_states
+        self.composer.lattice().min_cols = self.composer.lattice().getCols()
 
     def timestep(self):
         class LatticeSurgeryComputationSliceContextManager:

--- a/logical_lattice_ops.py
+++ b/logical_lattice_ops.py
@@ -213,6 +213,9 @@ class PiOverFourCorrectionCondition(EvaluationCondition):
         self.invert = invert
 
     def does_evaluate(self):
+        if not self.multi_body_measurement.does_evaluate():
+            return False
+
         out = self.multi_body_measurement.get_outcome()*self.ancilla_measurement.get_outcome() == -1
         if self.invert:
             out = not out
@@ -225,6 +228,9 @@ class PiOverEightCorrectionConditionPiOverFour(EvaluationCondition):
         self.invert = invert
 
     def does_evaluate(self):
+        if not self.multi_body_measurement.does_evaluate():
+            return False
+
         out = self.multi_body_measurement.get_outcome() == -1
         if self.invert:
             out = not out
@@ -235,4 +241,7 @@ class PiOverEightCorrectionConditionPiOverTwo(EvaluationCondition):
         self.ancilla_measurement = ancilla_measurement
 
     def does_evaluate(self):
+        if not self.ancilla_measurement.does_evaluate():
+            return False
+
         return self.ancilla_measurement.get_outcome() == -1

--- a/logical_patch_state_simulation.py
+++ b/logical_patch_state_simulation.py
@@ -25,16 +25,9 @@ class ConvertersToQiskit:
 
     @staticmethod
     def symbolic_state(s:SymbolicState)->qk.StateFn:
-        if s == DefaultSymbolicStates.Zero:
-            return qk.Zero
-        elif s == DefaultSymbolicStates.Plus:
-            return qk.One
-        elif s == DefaultSymbolicStates.YPosEigenState:
-            return (qk.Zero - 1j*qk.One)/math.sqrt(2)
-        elif s == DefaultSymbolicStates.Magic:
-            return (qk.Zero + cmath.exp(1j*math.pi/4)*qk.One)/math.sqrt(2)
-        else:
-            raise Exception("State cannot be converted to qiskit: "+repr(s))
+        zero_ampl, one_ampl = DefaultSymbolicStates.get_amplitudes(s)
+        return zero_ampl*qk.Zero + one_ampl*qk.One
+
 
 
 def circuit_add_op_to_qubit(circ : qk.CircuitOp, op: qk.PrimitiveOp, idx: int) -> qk.CircuitOp:

--- a/qubit_state.py
+++ b/qubit_state.py
@@ -15,7 +15,7 @@ class QubitActivity:
         self.activity_type = activity_type
     def ket_repr(self):
         if self.activity_type == ActivityType.Unitary: return self.op.value
-        if self.activity_type == ActivityType.Measurement: return self.op.value + "->"
+        if self.activity_type == ActivityType.Measurement: return "Measure "+ str(self.op.value) +" \n"
 
 class QubitState:
     def ket_repr(self):
@@ -64,8 +64,8 @@ class DefaultSymbolicStates():
     One = SymbolicState('|1>')
     Plus = SymbolicState('|+>')
     Minus = SymbolicState('|->')
-    YPosEigenState = SymbolicState('|Y_+>')
-    YNegEigenState = SymbolicState('|Y_->')
+    YPosEigenState = SymbolicState('|(Y+)>')
+    YNegEigenState = SymbolicState('|(Y-)>')
     Magic = SymbolicState('|m>')
     UnknownState = SymbolicState('|?>')
 
@@ -76,22 +76,36 @@ class DefaultSymbolicStates():
         zero_ampl /= mag
         one_ampl  /= mag
 
-        # TODO set global phase to 0
+        # Set global phase to 0
+        gphase = cmath.phase(zero_ampl)
+        zero_ampl /= cmath.exp(1j*gphase)
+        one_ampl  /= cmath.exp(1j*gphase)
 
-        close = lambda a,b: cmath.isclose(a,b,rel_tol=10**(-9))
+        close = lambda a,b: cmath.isclose(a,b,rel_tol=10**(-6))
 
         if close(zero_ampl,0): return DefaultSymbolicStates.One
         if close(one_ampl,0):  return DefaultSymbolicStates.Zero
-        if close(zero_ampl,cmath.sqrt(2)):
-            if close(one_ampl, cmath.sqrt(2)):            return DefaultSymbolicStates.Plus
-            if close(one_ampl,-cmath.sqrt(2)):            return DefaultSymbolicStates.Minus
-            if close(one_ampl, cmath.sqrt(2)*1j):         return DefaultSymbolicStates.YPosEigenState
-            if close(one_ampl,-cmath.sqrt(2)*1j):         return DefaultSymbolicStates.YNegEigenState
-            if close(one_ampl, cmath.exp(1j*cmath.pi/4)): return DefaultSymbolicStates.YNegEigenState
+        if close(zero_ampl,cmath.sqrt(2)/2):
+            if close(one_ampl, cmath.sqrt(2)/2):                            return DefaultSymbolicStates.Plus
+            if close(one_ampl,-cmath.sqrt(2)/2):                            return DefaultSymbolicStates.Minus
+            if close(one_ampl, cmath.sqrt(2)/2*1j):                         return DefaultSymbolicStates.YPosEigenState
+            if close(one_ampl,-cmath.sqrt(2)/2*1j):                         return DefaultSymbolicStates.YNegEigenState
+            if close(one_ampl, cmath.sqrt(2)/2*cmath.exp(1j*cmath.pi/4)):   return DefaultSymbolicStates.Magic
 
         return SymbolicState("{:.2f}|0>\n{:+.2f}|1>".format(zero_ampl,one_ampl))
 
 
+
+    @staticmethod
+    def get_amplitudes(s : SymbolicState) -> Tuple[complex,complex]:
+        """Returns in order the zero amplitude and the one amplitude"""
+        if s == DefaultSymbolicStates.Zero:             return 1, 0
+        if s == DefaultSymbolicStates.One:              return 0, 1
+        elif s == DefaultSymbolicStates.Plus:           return cmath.sqrt(2)/2,  cmath.sqrt(2)/2
+        elif s == DefaultSymbolicStates.Minus:          return cmath.sqrt(2)/2, -cmath.sqrt(2)/2
+        elif s == DefaultSymbolicStates.YPosEigenState: return cmath.sqrt(2)/2,  cmath.sqrt(2)/2*1j
+        elif s == DefaultSymbolicStates.YNegEigenState: return cmath.sqrt(2)/2, -cmath.sqrt(2)/2*1j
+        elif s == DefaultSymbolicStates.Magic:          return cmath.sqrt(2)/2,  cmath.exp(1j*cmath.pi/4)/cmath.sqrt(2)
 
 
 

--- a/qubit_state.py
+++ b/qubit_state.py
@@ -50,7 +50,7 @@ class ActiveState(QubitState):
         if self.activity.activity_type == ActivityType.Measurement:
             return "Measuring {:s}:\n{:s}".format(str(self.activity.op),self.next.ket_repr())
         if self.activity.activity_type == ActivityType.Unitary:
-            if self.prev == DefalutSymbolicStates.UnknownState:
+            if isinstance(self.prev,EntangledState):
                 return "Apply {:s}\n to entangled\n state".format(self.activity.op)
             elif len(self.prev.ket_repr()+self.prev.ket_repr())<10:
                 # Compact printing
@@ -58,13 +58,16 @@ class ActiveState(QubitState):
             else:
                 return "{:s}({:s})\n={:s}".format(str(self.activity.op),self.prev.ket_repr(),self.next.ket_repr())
 
-
-
-
     def disappears(self):
         return self.activity.activity_type == ActivityType.Measurement
 
 
+class EntangledState(SymbolicState):
+    def __init__(self):
+        super().__init__("Entangled")
+
+    def ket_repr(self):
+        return "Entangled"
 
 
 class DefaultSymbolicStates():

--- a/qubit_state.py
+++ b/qubit_state.py
@@ -13,9 +13,6 @@ class QubitActivity:
     def __init__(self, op:PauliOperator, activity_type: ActivityType):
         self.op = op
         self.activity_type = activity_type
-    def ket_repr(self):
-        if self.activity_type == ActivityType.Unitary: return self.op.value
-        if self.activity_type == ActivityType.Measurement: return "Measure "+ str(self.op.value) +" \n"
 
 class QubitState:
     def ket_repr(self):
@@ -50,7 +47,19 @@ class ActiveState(QubitState):
         self.activity = activity
 
     def ket_repr(self):
-        return self.activity.ket_repr() + self.prev.ket_repr()
+        if self.activity.activity_type == ActivityType.Measurement:
+            return "Measuring {:s}:\n{:s}".format(str(self.activity.op),self.next.ket_repr())
+        if self.activity.activity_type == ActivityType.Unitary:
+            if self.prev == DefalutSymbolicStates.UnknownState:
+                return "Apply {:s}\n to entangled\n state".format(self.activity.op)
+            elif len(self.prev.ket_repr()+self.prev.ket_repr())<10:
+                # Compact printing
+                return str(self.activity.op) + self.prev.ket_repr() + " = "+ self.next.ket_repr()
+            else:
+                return "{:s}({:s})\n={:s}".format(str(self.activity.op),self.prev.ket_repr(),self.next.ket_repr())
+
+
+
 
     def disappears(self):
         return self.activity.activity_type == ActivityType.Measurement


### PR DESCRIPTION
Since now states are tracked in one big register as a single state, instead of tracking the evolution of single states individually, we assign states to them by extracting them from the global state.

On top of that there were some other things broken by the pull requests #46 and #51. Most notably T gate handling because of magic state routing problems.