### PR TITLE
Option to disable Y operator removal

### DIFF
--- a/circuit.py
+++ b/circuit.py
@@ -80,7 +80,8 @@ class Circuit(object):
         self.add_pauli_block(new_rotation, index)
 
 
-    def apply_transformation(self) -> None:
+
+    def apply_transformation(self, start_index:int=0, remove_y_operators:bool = True) -> None:
         """
         Apply Litinski's Transformation
 
@@ -100,9 +101,10 @@ class Circuit(object):
                 self.commute_pi_over_four_rotation(index)
                 index += 1
             self.ops.pop()
-        
-        # Remove all pi/4 rotations from the circuit
-        self.remove_y_operators_from_circuit()
+
+
+        if remove_y_operators:
+            self.remove_y_operators_from_circuit()
 
 
     def remove_y_operators_from_circuit(self) -> None:

--- a/debug/debug_litinski_transform_takes_up_space.py
+++ b/debug/debug_litinski_transform_takes_up_space.py
@@ -1,0 +1,27 @@
+from lattice_surgery_computation_composer import *
+from logical_patch_state_simulation import qk
+from webgui import lattice_view
+from debug.util import *
+
+if __name__ == "__main__":
+    c = Circuit(4)
+    I = PauliOperator.I
+    X = PauliOperator.X
+    Y = PauliOperator.Y
+    Z = PauliOperator.Z
+
+    c.add_pauli_block(Rotation.from_list([X, Z, I, I], Fraction(1, 4)))
+    c.add_pauli_block(Rotation.from_list([I, I, X, X], Fraction(1, 4)))
+    c.add_pauli_block(Rotation.from_list([I, I, Z, I], Fraction(1, 8)))
+    c.add_pauli_block(Rotation.from_list([I, X, I, I], Fraction(1, 8)))
+
+    print("Starting circuit:")
+    print(c.render_ascii())
+
+    c.apply_transformation(remove_y_operators=False)
+    print("Removed stabilizer rotations:")
+    print(c.render_ascii())
+
+    print("Removed y operators:")
+    c.remove_y_operators_from_circuit()
+    print(c.render_ascii())


### PR DESCRIPTION
Used to make the example in the presentation where the stabilizer removal transform was applied without removing the Y operators from Pauli rotations. Probably worth keeping.