### PR TITLE
Add method to render circuit in latex 

### DIFF
--- a/assets/circuit_latex_render.mak
+++ b/assets/circuit_latex_render.mak
@@ -1,0 +1,43 @@
+## MAKO TEMPLATE FOR GENERATING CIRCUIT RENDER IN LATEX
+##
+\documentclass{article}
+\usepackage{tikz}
+\usetikzlibrary{backgrounds,fit,decorations.pathreplacing,calc}
+
+\begin{document}
+
+\begin{tikzpicture}
+    \tikzstyle{paulicomponent} = [draw,draw=none,fill=white,minimum size=1.5em] 
+    \tikzstyle{phase} = [draw,fill,shape=circle,minimum size=5pt,inner sep=0pt]
+    \matrix[row sep=0.4cm, column sep=0.4cm] (circuit) {
+    
+    ## Generate each row:
+    % for i in range(qubit_num):
+        \node (q${i}) {$q_1$}; &[-0.1cm]
+        % for j in range(i, len(operator_list), qubit_num):
+        \node[paulicomponent] (H${j}) {${operator_list[j]}}; &
+        %endfor 
+        \coordinate (end${i}); \\\
+
+        ## Won't need the below line later (when adding phase labels)
+        % if i == qubit_num - 1: 
+    }; 
+        % endif 
+
+    ## Drawing borders for each Pauli operation:
+    % endfor
+    % for k in range(0, len(operator_list), qubit_num):
+        \draw (H${k}.north east) rectangle (H${(k+qubit_num-1)}.south west);
+    % endfor 
+    
+    ## Drawing circuit lines: 
+    \begin{pgfonlayer}{background}
+        \draw[thick]
+        % for i in range(qubit_num): 
+        (q${i}) -- (end${i})
+        % endfor
+        ;
+    \end{pgfonlayer}
+    
+\end{tikzpicture}
+\end{document}

--- a/circuit.py
+++ b/circuit.py
@@ -314,7 +314,37 @@ class Circuit(object):
     def count_rotations_by(self, rotation_amount : Fraction) -> int:
         return len(list(filter(lambda r: isinstance(r, Rotation) and r.rotation_amount==rotation_amount, self.ops)))
 
-   
+
+    def render_latex(self) -> str:
+        """
+        Generate latex render output of the current circuit. 
+
+        """
+        # NOTE: INCOMPLETE
+        from mako.template import Template
+        latex_template = Template(filename='assets\circuit_latex_render.mak')
+
+        operator_list = list()
+        phase_list = list()
+        for operation in self.ops:
+            for operator in operation.ops_list:
+                operator_list += str(operator) 
+            
+            if isinstance(operation, Rotation):
+                phase_list.append((operation.rotation_amount.numerator, operation.rotation_amount.numerator)) 
+            elif isinstance(operation, Measurement):
+                operator_str = '-M' if operation.isNegative else 'M'
+                phase_list.append(operator_str)
+
+        doc_params = dict(
+            qubit_num = self.qubit_num,
+            operator_list = operator_list,
+            phase_list = phase_list, 
+        )
+
+        return latex_template.render(**doc_params)
+
+
     def render_ascii(self) -> str:
         """
         Return circuit diagram in text format 

--- a/debug/debug_circuit_render_latex.py
+++ b/debug/debug_circuit_render_latex.py
@@ -1,0 +1,22 @@
+# Test case for Circuit.render_latex()
+
+from circuit import *
+from rotation import *
+
+I = PauliOperator.I 
+X = PauliOperator.X 
+Z = PauliOperator.Z 
+Y = PauliOperator.Y  
+
+# Random example
+c = Circuit(4)
+c.add_pauli_block(Rotation.from_list([Z, I, I, I],Fraction(1,8)))
+c.add_pauli_block(Rotation.from_list([I, X, Z, I],Fraction(1,4)))
+c.add_pauli_block(Rotation.from_list([I, I, I, X],Fraction(-1,4)))
+c.add_pauli_block(Rotation.from_list([X, I, I, I],Fraction(-1,4)))
+c.add_pauli_block(Rotation.from_list([I, X, I, I],Fraction(-1,4)))
+c.add_pauli_block(Measurement.from_list([Z, I, I, I]))
+c.add_pauli_block(Measurement.from_list([I, Z, I, I]))
+c.add_pauli_block(Measurement.from_list([I, I, Z, I]))
+
+print(c.render_latex())


### PR DESCRIPTION
Currently functional. Missing phase labelling and adaptive sizing (can be difficult to implement). May have difficulties with long circuit due to limited width of document. The method uses `mako` package for template library. 