### PR TITLE
Add phase labelling for latex rendering 

### DIFF
--- a/assets/circuit_latex_render.mak
+++ b/assets/circuit_latex_render.mak
@@ -6,7 +6,9 @@
 
 \begin{document}
 
-\begin{tikzpicture}
+\hoffset=-1in
+\voffset=-1in
+\setbox0\hbox{\begin{tikzpicture}
     \tikzstyle{paulicomponent} = [draw,draw=none,fill=white,minimum size=1.5em] 
     \tikzstyle{phase} = [draw,fill,shape=circle,minimum size=5pt,inner sep=0pt]
     \matrix[row sep=0.4cm, column sep=0.4cm] (circuit) {
@@ -46,5 +48,10 @@
         ;
     \end{pgfonlayer}
     
-\end{tikzpicture}
+\end{tikzpicture}}
+\pdfpageheight=\dimexpr\ht0+\dp0\relax
+\pdfpagewidth=\wd0
+\shipout\box0
+
+\stop
 \end{document}

--- a/assets/circuit_latex_render.mak
+++ b/assets/circuit_latex_render.mak
@@ -15,9 +15,9 @@
     
     ## Generate each row:
     % for i in range(qubit_num):
-        \node (q${i}) {$q_1$}; &[-0.1cm]
+        \node (q${i}) {$q_${i}$}; &[-0.1cm]
         % for j in range(i, len(operator_list), qubit_num):
-        \node[paulicomponent] (H${j}) {${operator_list[j]}}; &
+        \node[paulicomponent] (op${j}) {${operator_list[j]}}; &
         %endfor 
         \coordinate (end${i}); \\\
 
@@ -36,7 +36,7 @@
 
     ## Drawing borders for each Pauli operation:
     % for k in range(0, len(operator_list), qubit_num):
-    \draw (H${k}.north east) rectangle (H${(k+qubit_num-1)}.south west);
+    \draw (op${k}.north east) rectangle (op${(k+qubit_num-1)}.south west);
     % endfor 
     
     ## Drawing circuit lines: 

--- a/assets/circuit_latex_render.mak
+++ b/assets/circuit_latex_render.mak
@@ -19,15 +19,22 @@
         %endfor 
         \coordinate (end${i}); \\\
 
-        ## Won't need the below line later (when adding phase labels)
-        % if i == qubit_num - 1: 
-    }; 
-        % endif 
+    % endfor
+        [-0.3cm]
+        ##
+        ## Phase labelling:
+        ##
+        \node (op_angle_begin) {}; &
+    % for phase_label in phase_list:
+        \node[paulicomponent] {${phase_label}}; &
+    %endfor
+        \coordinate (op_angle_end); \\\
+
+    };
 
     ## Drawing borders for each Pauli operation:
-    % endfor
     % for k in range(0, len(operator_list), qubit_num):
-        \draw (H${k}.north east) rectangle (H${(k+qubit_num-1)}.south west);
+    \draw (H${k}.north east) rectangle (H${(k+qubit_num-1)}.south west);
     % endfor 
     
     ## Drawing circuit lines: 

--- a/circuit.py
+++ b/circuit.py
@@ -330,11 +330,19 @@ class Circuit(object):
             for operator in operation.ops_list:
                 operator_list += str(operator) 
             
+            # Latex format for phase label (I didnt want to do this in the template file)
             if isinstance(operation, Rotation):
-                phase_list.append((operation.rotation_amount.numerator, operation.rotation_amount.numerator)) 
+                operator_str = '$\\frac{'
+                if abs(operation.rotation_amount.numerator) != 1:
+                    operator_str += str(operation.rotation_amount.numerator)
+                elif operation.rotation_amount.numerator == -1:
+                    operator_str += '-'
+                operator_str += '\pi}{' + str(operation.rotation_amount.denominator) + '}$'
+
             elif isinstance(operation, Measurement):
                 operator_str = '-M' if operation.isNegative else 'M'
-                phase_list.append(operator_str)
+            
+            phase_list.append(operator_str)
 
         doc_params = dict(
             qubit_num = self.qubit_num,

--- a/circuit.py
+++ b/circuit.py
@@ -1,7 +1,7 @@
 import numpy as np 
 from rotation import PauliProductOperation, Rotation, Measurement, PauliOperator
 from fractions import Fraction
-from utils import decompose_pi_fraction
+from utils import decompose_pi_fraction, phase_frac_to_latex
 import pyzx as zx
 from typing import *
 
@@ -320,7 +320,7 @@ class Circuit(object):
         Generate latex render output of the current circuit. 
 
         """
-        # NOTE: INCOMPLETE
+
         from mako.template import Template
         latex_template = Template(filename='assets\circuit_latex_render.mak')
 
@@ -332,12 +332,7 @@ class Circuit(object):
             
             # Latex format for phase label (I didnt want to do this in the template file)
             if isinstance(operation, Rotation):
-                operator_str = '$\\frac{'
-                if abs(operation.rotation_amount.numerator) != 1:
-                    operator_str += str(operation.rotation_amount.numerator)
-                elif operation.rotation_amount.numerator == -1:
-                    operator_str += '-'
-                operator_str += '\pi}{' + str(operation.rotation_amount.denominator) + '}$'
+                operator_str = '$' + phase_frac_to_latex(operation.rotation_amount) + '$'
 
             elif isinstance(operation, Measurement):
                 operator_str = '-M' if operation.isNegative else 'M'

--- a/debug/debug_circuit_render_latex.py
+++ b/debug/debug_circuit_render_latex.py
@@ -15,8 +15,11 @@ c.add_pauli_block(Rotation.from_list([I, X, Z, I],Fraction(1,4)))
 c.add_pauli_block(Rotation.from_list([I, I, I, X],Fraction(-1,4)))
 c.add_pauli_block(Rotation.from_list([X, I, I, I],Fraction(-1,4)))
 c.add_pauli_block(Rotation.from_list([I, X, I, I],Fraction(-1,4)))
-c.add_pauli_block(Measurement.from_list([Z, I, I, I]))
+c.add_pauli_block(Rotation.from_list([I, X, I, I],Fraction(-5,4)))
+c.add_pauli_block(Measurement.from_list([Z, I, I, I], True))
 c.add_pauli_block(Measurement.from_list([I, Z, I, I]))
 c.add_pauli_block(Measurement.from_list([I, I, Z, I]))
+c.add_pauli_block(Measurement.from_list([Y, X, Z, I], True))
+
 
 print(c.render_latex())

--- a/rotation.py
+++ b/rotation.py
@@ -3,6 +3,7 @@ from typing import *
 from enum import Enum
 from fractions import Fraction
 import qiskit.aqua.operators
+from utils import phase_frac_to_latex
 
 
 class PauliOperator(Enum):
@@ -159,12 +160,7 @@ class Rotation(PauliProductOperation):
 
     def to_latex(self) -> str:
         return_str = super().to_latex() 
-        return_str += '_\\frac{'
-        if abs(self.rotation_amount.numerator) != 1:
-            return_str += str(self.rotation_amount.numerator)
-        elif self.rotation_amount.numerator == -1:
-            return_str += '-'
-        return_str += '\pi}{' + str(self.rotation_amount.denominator) + '}'
+        return_str += '_' + phase_frac_to_latex(self.rotation_amount)
 
         return return_str
 

--- a/rotation.py
+++ b/rotation.py
@@ -88,6 +88,15 @@ class PauliProductOperation(ConditionalOperation):
         return str(self)
 
     
+    def to_latex(self) -> str:
+        return_str = '(' + str(self.ops_list[0])
+        if self.qubit_num > 1: 
+            for i in range(1, len(self.ops_list)):
+                return_str += ' \otimes' + ' ' + str(self.ops_list[i])
+        return_str += ')'
+        return return_str
+
+
     def change_single_op(self, qubit: int, new_op: PauliOperator) -> None:
         """
         Modify a Pauli Operator
@@ -147,7 +156,19 @@ class Rotation(PauliProductOperation):
     def __str__(self) -> str:
         return '{}: {}'.format(self.rotation_amount, self.ops_list) 
             
-        
+
+    def to_latex(self) -> str:
+        return_str = super().to_latex() 
+        return_str += '_\\frac{'
+        if abs(self.rotation_amount.numerator) != 1:
+            return_str += str(self.rotation_amount.numerator)
+        elif self.rotation_amount.numerator == -1:
+            return_str += '-'
+        return_str += '\pi}{' + str(self.rotation_amount.denominator) + '}'
+
+        return return_str
+
+
     @staticmethod
     def from_list(pauli_ops: List[PauliOperator], rotation: Fraction) -> 'Rotation':
         r = Rotation(len(pauli_ops), rotation)
@@ -179,6 +200,11 @@ class Measurement(PauliProductOperation):
     def __str__(self) -> str:
         return '{}M: {}'.format('-' if self.isNegative else '', self.ops_list) 
 
+
+    def to_latex(self) -> str:
+        return_str = super().to_latex() 
+        return_str += '_{-M}' if self.isNegative else '_M' 
+        return return_str
 
     @staticmethod
     def from_list(pauli_ops: List[PauliOperator], isNegative: bool = False) -> 'Measurement':

--- a/utils.py
+++ b/utils.py
@@ -23,3 +23,18 @@ def decompose_pi_fraction(f:Fraction):
       largest_pow_of_2 = int(pow(2, p))  
       return [Fraction(largest_pow_of_2, f.denominator)] \
         + decompose_pi_fraction(Fraction(f.numerator - largest_pow_of_2,f.denominator))
+
+
+def phase_frac_to_latex(phi : Fraction):
+  """Assumes phi is multiplied by pi"""
+  if phi.numerator== 0: return "0"
+
+  sign = "" if phi.numerator > 0 else "-"
+  num = "" if abs(phi.numerator) == 1 else str(abs(phi.numerator))
+
+  if phi.denominator == 1:
+    return "%s%s\\pi"%(sign,num)
+
+  den = str(phi.denominator)
+
+  return "%s\\frac{%s\\pi}{%s}"%(sign,num,den)


### PR DESCRIPTION
As title. Below is the screenshot of the latex rendering for the circuit in `debug/debug_circuit_render_latex.py`.

![image](https://user-images.githubusercontent.com/46719079/115974621-de26a100-a512-11eb-8cf0-8dd4a25bc9aa.png)
