### PR TITLE
Add non Litinski Operations

### DIFF
--- a/circuit.py
+++ b/circuit.py
@@ -6,15 +6,15 @@ from utils import decompose_pi_fraction, phase_frac_to_latex
 import pyzx as zx
 from typing import *
 
-class Circuit(object):
+class PauliCircuit(object):
     """
-    Class for representing quantum circuit.
+    Class for representing quantum Pauli circuit.
 
     """
 
     def __init__(self, no_of_qubit: int, name: str = '') -> None:
         """
-        Generating a circuit
+        Generating a Pauli circuit
 
         Args:
             no_of_qubit (int): Number of qubits in the circuit
@@ -37,7 +37,7 @@ class Circuit(object):
         return len(self.ops)
 
 
-    def copy(self) -> 'Circuit':
+    def copy(self) -> 'PauliCircuit':
         return copy.deepcopy(self)
 
 
@@ -174,7 +174,7 @@ class Circuit(object):
             raise Exception("First operand must be +-pi/4 Pauli rotation")
 
         # Need to calculate iPP' when PP' = -P'P (anti-commute)
-        if not Circuit.are_commuting(self.ops[index], self.ops[next_block]):
+        if not PauliCircuit.are_commuting(self.ops[index], self.ops[next_block]):
             product_of_coefficients = 1
             
             for i in range(self.qubit_num):
@@ -231,9 +231,9 @@ class Circuit(object):
     
 
     @staticmethod
-    def load_from_pyzx(circuit) -> 'Circuit':
+    def load_from_pyzx(circuit) -> 'PauliCircuit':
         """
-        Generate circuit from PyZX Circuit
+        Generate Pauli circuit from PyZX Circuit
 
         Returns:
             circuit: PyZX Circuit
@@ -243,7 +243,7 @@ class Circuit(object):
         Z = PauliOperator.Z
 
         basic_circ = circuit.to_basic_gates()
-        ret_circ = Circuit(basic_circ.qubits, circuit.name)
+        ret_circ = PauliCircuit(basic_circ.qubits, circuit.name)
 
         gate_missed = 0
 
@@ -299,18 +299,18 @@ class Circuit(object):
         return ret_circ
 
     @staticmethod
-    def load_reversible_from_qasm_string(quasm_string: str) -> 'Circuit':
+    def load_reversible_from_qasm_string(quasm_string: str) -> 'PauliCircuit':
         """
         Load a string as if it were a QASM circuit. Only supports reversible circuits.
         """
 
         pyzx_circ = zx.Circuit.from_qasm(quasm_string)
-        ret_circ = Circuit.load_from_pyzx(pyzx_circ)
+        ret_circ = PauliCircuit.load_from_pyzx(pyzx_circ)
 
         return ret_circ
 
     @staticmethod
-    def join(lhs: 'Circuit', rhs: 'Circuit') -> 'Circuit':
+    def join(lhs: 'PauliCircuit', rhs: 'PauliCircuit') -> 'PauliCircuit':
         assert lhs.qubit_num == rhs.qubit_num
         c = lhs.copy()
         c.ops.extend(rhs.ops)

--- a/debug/debug_apply_logical_operation.py
+++ b/debug/debug_apply_logical_operation.py
@@ -2,7 +2,7 @@ from lattice_surgery_computation_composer import *
 from webgui import lattice_view
 
 if __name__ == "__main__":
-    c = Circuit(4)
+    c = PauliCircuit(4)
     I = PauliOperator.I
     X = PauliOperator.X
     Y = PauliOperator.Y

--- a/debug/debug_basic_dependency_graph.py
+++ b/debug/debug_basic_dependency_graph.py
@@ -8,7 +8,7 @@ Z = PauliOperator.Z
 Y = PauliOperator.Y  
 
 # Example from #71 as the base test case
-c = Circuit(2)
+c = PauliCircuit(2)
 c.add_pauli_block(Rotation.from_list([X, X],Fraction(1,8)))
 c.add_pauli_block(Rotation.from_list([Z, Z],Fraction(1,4)))
 c.add_pauli_block(Rotation.from_list([X, Z],Fraction(-1,4)))

--- a/debug/debug_circuit_render_ascii.py
+++ b/debug/debug_circuit_render_ascii.py
@@ -11,7 +11,7 @@ pi*  1/2  1/4  1/8 -1/8  1/16 -1/16   M   -M
 """
 
 if __name__ == "__main__":
-    c = Circuit(4)
+    c = PauliCircuit(4)
 
     I = PauliOperator.I
     X = PauliOperator.Z

--- a/debug/debug_circuit_render_latex.py
+++ b/debug/debug_circuit_render_latex.py
@@ -9,7 +9,7 @@ Z = PauliOperator.Z
 Y = PauliOperator.Y  
 
 # Random example
-c = Circuit(4)
+c = PauliCircuit(4)
 c.add_pauli_block(Rotation.from_list([Z, I, I, I],Fraction(1,8)))
 c.add_pauli_block(Rotation.from_list([I, X, Z, I],Fraction(1,4)))
 c.add_pauli_block(Rotation.from_list([I, I, I, X],Fraction(-1,4)))

--- a/debug/debug_gui_consecutive_ops.py
+++ b/debug/debug_gui_consecutive_ops.py
@@ -3,7 +3,7 @@ from webgui import lattice_view
 from debug.util import *
 
 if __name__ == "__main__":
-    c = Circuit(4)
+    c = PauliCircuit(4)
     I = PauliOperator.I
     X = PauliOperator.X
     Y = PauliOperator.Y

--- a/debug/debug_litinski_transform_seminar_example.py
+++ b/debug/debug_litinski_transform_seminar_example.py
@@ -6,7 +6,7 @@ X = PauliOperator.X
 Z = PauliOperator.Z 
 Y = PauliOperator.Y  
 
-c = Circuit(4)
+c = PauliCircuit(4)
 
 c.add_pauli_block(Rotation.from_list([Z, I, I, I],Fraction(1,8)))
 c.add_pauli_block(Rotation.from_list([I, X, Z, I],Fraction(1,4)))

--- a/debug/debug_litinski_transform_takes_up_space.py
+++ b/debug/debug_litinski_transform_takes_up_space.py
@@ -4,7 +4,7 @@ from webgui import lattice_view
 from debug.util import *
 
 if __name__ == "__main__":
-    c = Circuit(4)
+    c = PauliCircuit(4)
     I = PauliOperator.I
     X = PauliOperator.X
     Y = PauliOperator.Y

--- a/debug/debug_pauli_rotations_to_lattice_surgery.py
+++ b/debug/debug_pauli_rotations_to_lattice_surgery.py
@@ -2,7 +2,7 @@ from lattice_surgery_computation_composer import *
 from webgui import lattice_view
 
 if __name__ == "__main__":
-    c = Circuit(1)
+    c = PauliCircuit(1)
     I = PauliOperator.I
     X = PauliOperator.X
     Y = PauliOperator.Y

--- a/debug/debug_pi_over_eight_routing.py
+++ b/debug/debug_pi_over_eight_routing.py
@@ -3,7 +3,7 @@ from webgui import lattice_view
 from debug.util import *
 
 if __name__ == "__main__":
-    c = Circuit(4)
+    c = PauliCircuit(4)
     I = PauliOperator.I
     X = PauliOperator.X
     Y = PauliOperator.Y

--- a/debug/debug_qubit_ordering_separation.py
+++ b/debug/debug_qubit_ordering_separation.py
@@ -3,7 +3,7 @@ from webgui import lattice_view
 from debug.util import *
 
 if __name__ == "__main__":
-    c = Circuit(4)
+    c = PauliCircuit(4)
     I = PauliOperator.I
     X = PauliOperator.X
     Y = PauliOperator.Y

--- a/debug/debug_simulation_separations.py
+++ b/debug/debug_simulation_separations.py
@@ -4,7 +4,7 @@ from webgui import lattice_view
 from debug.util import *
 
 if __name__ == "__main__":
-    c = Circuit(4)
+    c = PauliCircuit(4)
     I = PauliOperator.I
     X = PauliOperator.X
     Y = PauliOperator.Y

--- a/dependency_graph.py
+++ b/dependency_graph.py
@@ -29,14 +29,14 @@ class DependencyGraph:
 
 
     @staticmethod
-    def from_circuit_by_commutation(circuit: Circuit) -> 'DependencyGraph':
+    def from_circuit_by_commutation(circuit: PauliCircuit) -> 'DependencyGraph':
         """
         Build a dependency tree from a Pauli circuit based on commutation.
 
         """
         # This because new dependency is added between non-commuting operations  
         def func(arg1, arg2):
-            return not Circuit.are_commuting(arg1, arg2)
+            return not PauliCircuit.are_commuting(arg1, arg2)
         
         return DependencyGraph.from_list(circuit.ops, func)
 

--- a/dependency_graph.py
+++ b/dependency_graph.py
@@ -34,6 +34,9 @@ class DependencyGraph:
         Build a dependency tree from a Pauli circuit based on commutation.
 
         """
+        if circuit.has_transversal_op():
+            raise NotImplementedError("Method not supports transversal operations")
+
         # This because new dependency is added between non-commuting operations  
         def func(arg1, arg2):
             return not PauliCircuit.are_commuting(arg1, arg2)

--- a/logical_lattice_ops.py
+++ b/logical_lattice_ops.py
@@ -3,7 +3,7 @@ from rotation import *
 import uuid
 from collections import deque
 from qubit_state import *
-from circuit import Circuit
+from circuit import PauliCircuit
 
 
 # TODO give a uuid to all patches
@@ -65,7 +65,7 @@ class MagicStateRequest(LogicalLatticeOperation):
 
 class LogicalLatticeComputation:
     
-    def __init__(self, circuit: Circuit):
+    def __init__(self, circuit: PauliCircuit):
         self.circuit = circuit
         self.logical_qubit_uuid_map = dict([(j,uuid.uuid4()) for j in range(circuit.qubit_num)])
         self.ops : List[LogicalLatticeOperation] = []

--- a/transversal_op.py
+++ b/transversal_op.py
@@ -1,4 +1,6 @@
 from conditional_operation_control import *
+from rotation import Rotation, PauliOperator
+from fractions import Fraction
 
 class TransversalOp():
     pass 
@@ -8,7 +10,35 @@ class Hadamard(TransversalOp):
     def __init__(self, target):
         self.qubit: int = target
 
-class CNOT(TransversalOp):
-    def __init__(self, control, target):
-        self.control: int = control
-        self.target: int = target
+    def to_pauli_rotation(self, qubit_count):
+        rotation1 = Rotation(qubit_count, Fraction(1,4))
+        rotation1.change_single_op(self.qubit, PauliOperator.X)
+
+        rotation2 = Rotation(qubit_count, Fraction(1,4))
+        rotation2.change_single_op(self.qubit, PauliOperator.Z)
+
+        rotation3 = Rotation(qubit_count, Fraction(1,4))
+        rotation3.change_single_op(self.qubit, PauliOperator.X)
+
+        return rotation1, rotation2, rotation3
+        
+
+class TransversalX(TransversalOp):
+    def __init__(self, target):
+        self.qubit: int = target
+
+    def to_pauli_rotation(self, qubit_count):
+        ret_rotation = Rotation(qubit_count, Fraction(1,2))
+        ret_rotation.change_single_op(self.qubit, PauliOperator.X)
+        return ret_rotation
+
+
+class TransversalY(TransversalOp):
+    def __init__(self, target):
+        self.qubit: int = target
+
+    
+    def to_pauli_rotation(self, qubit_count):
+        ret_rotation = Rotation(qubit_count, Fraction(1,2))
+        ret_rotation.change_single_op(self.qubit, PauliOperator.Z)
+        return ret_rotation

--- a/transversal_op.py
+++ b/transversal_op.py
@@ -5,7 +5,10 @@ class TransversalOp():
 
 
 class Hadamard(TransversalOp):
-    pass
+    def __init__(self, target):
+        self.qubit: int = target
 
 class CNOT(TransversalOp):
-    pass
+    def __init__(self, control, target):
+        self.control: int = control
+        self.target: int = target

--- a/transversal_op.py
+++ b/transversal_op.py
@@ -1,0 +1,11 @@
+from conditional_operation_control import *
+
+class TransversalOp():
+    pass 
+
+
+class Hadamard(TransversalOp):
+    pass
+
+class CNOT(TransversalOp):
+    pass


### PR DESCRIPTION
This is part of the bigger task #96.

Initially we thought in #91 and #93 to add just Transversal operations, but in the Horsman et al. paper there is a precise protocol for CNOT that doesn't require converting to PauliRotations before lattice surgery. We could use that directly. That means adding another kind of operation, which is  neither transversal nor Litinski. It's the original kind of lattice surgery.