### PR TITLE
Integrate `pre-commit` 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# See https://pre-commit.com for more information
+
+default_language_version:
+  python: python3.9
+
+default_stages: [commit, push]
+exclude: ^debug/
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-case-conflict
+      - id: name-tests-test
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.0
+    hooks:
+      - id: isort
+        args: ["--check"]
+
+  - repo: https://github.com/ambv/black
+    rev: 21.10b0
+    hooks:
+      - id: black
+        args: ["--check"]
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+      - id: mypy

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ Then install the package in edit mode:
 
 Now you can use this venv to work the package, from the command line and in an IDE. Make sure to select the venv you just created as the python environment for the project in your IDE.
 
+#### Pre commit hooks
+ Pre commit-hooks run type and style checks before every commit. Useful to avoid having to wait for feedback from CI and taking som load off of our pipelines.
+
+Set up instructions:
+* `pip install pre-commit` and then `pre-commit install` 
+* To run: `pre-commit run` or just `git commit ...`, the first time running will take a while since it has to clone all the repos specified in `pre-commit-config.yaml`
+
+If want to run against all files (good for first run to test things out): `pre-commit run -a`. 
+
+
+
 ## References
 <a id="1">[1]</a> 
 Alexandru Paler and Austin G Fowler. 


### PR DESCRIPTION
Closes #124 

How to run:
* `pip install pre-commit` and then `pre-commit install` 
* To run: `pre-commit run` or just `git commit ...`, the first time running will take a while since it has to clone all the repos specified in `pre-commit-config.yaml`
* If want to run against all files (good for first run to test things out): `pre-commit run -a`. 
