### PR TITLE
Update `pre-commit` configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,9 @@
 default_language_version:
   python: python3.9
 
+ci:
+  autofix_prs: false
+
 default_stages: [commit, push]
 exclude: ^debug/
 
@@ -11,19 +14,17 @@ repos:
     rev: v4.0.1
     hooks:
       - id: check-case-conflict
-      - id: name-tests-test
+      - id: check-docstring-first
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.0
     hooks:
       - id: isort
-        args: ["--check"]
 
   - repo: https://github.com/ambv/black
     rev: 21.10b0
     hooks:
       - id: black
-        args: ["--check"]
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 4.0.1

--- a/src/lsqecc/logical_lattice_ops/logical_lattice_ops.py
+++ b/src/lsqecc/logical_lattice_ops/logical_lattice_ops.py
@@ -32,7 +32,7 @@ from lsqecc.pauli_rotations import (
 
 # TODO give a uuid to all patches
 
-"""Patches are now identified by uuids"""
+# Patches are now identified by uuids
 
 
 class LogicalLatticeOperation(coc.ConditionalOperation):


### PR DESCRIPTION
Changes:
* Remove `name-test-test` hook (it checks if files in tests/ end with `_test.py`) - removing because it might interfere when we are using pytest Fixture functions (and I prefer `test_*.py` better). 
* Adding `check-docstring-first` which checks for instances of code being placed in front of docstring. Fix one instance where this occurs.
* Remove `--check` option for both black and isort - this means pre-commit will applies change to your code (would have to do `git add` again if that happens). This also allow pre-commit.ci tool to push changes generated by those formatters to a PR - which I have set to off by default. If you want that to happen, comment "pre-commit.ci autofix" under your PR (~~also I would need to test that out after this PR is merged~~ Tested on #144). 

Finally here is [a list of all out-of-the-box hooks](https://github.com/pre-commit/pre-commit-hooks/blob/master/README.md) available. Let me know if you want any of them to be implemented. 
