### PR TITLE
Add documentation directory 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,4 +5,5 @@ exclude =
     .git,
     __init__.py,
     __pycache__,
-    debug
+    debug,
+    docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,23 @@ jobs:
       run: |
         pip install --upgrade pip build setuptools wheel
         python -m build
+
+  doc:
+    name: Build Doc
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+        
+    - name: Install dependencies
+      run: |
+        pip install -r docs/requirements.txt
+    
+    - name: Build doc 
+      run: |
+        cd docs
+        make html 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,23 +60,3 @@ jobs:
       run: |
         pip install --upgrade pip build setuptools wheel
         python -m build
-
-  doc:
-    name: Build Doc
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-        
-    - name: Install dependencies
-      run: |
-        pip install -r docs/requirements.txt
-    
-    - name: Build doc 
-      run: |
-        cd docs
-        make html 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,14 @@ on:
       - '**.md'
       - 'debug/**'
       - 'assets/**'
+      - 'docs/**'
   pull_request:
     branches: [ master, dev ]
     paths-ignore:
       - '**.md'
       - 'debug/**'
       - 'assets/**'
+      - 'docs/**'
 
 jobs:
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
   autofix_prs: false
 
 default_stages: [commit, push]
-exclude: ^debug/
+exclude: (^debug/|^docs/)
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+<!-- start -->
+
 ## Getting Started
 
 If you just want to get an idea for what this compiler does, check out https://latticesurgery.com.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ Compile logical circuits to lattice surgery operations on a surface code lattice
 ![image](https://user-images.githubusercontent.com/36427091/104856854-98ca5600-58c9-11eb-9599-286c1d5a4736.png)
 
 ## Overview
+
+<!-- start overview -->
+
 A compiler that takes a QASM circuit and turns it into abstract lattice surgery instructions.
 
 Our long term vision is to have an end to end lattice surgery compiler. We want it to be able to take a manually programmed circuit and ouput a large error corrected circuit, that performs the same computation with many more qubits and a higher degree of accuracy.
+
+<!-- end overview -->
 
 #### Features:
 * Web-based patch visualizer that shows a computation happening on a surface code lattice (in picture). Try it at https://latticesurgery.com.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,26 @@
 # Lattice Surgery Compiler
 [![Unitary Fund](https://img.shields.io/badge/Supported%20By-UNITARY%20FUND-brightgreen.svg?style=for-the-badge)](http://unitary.fund)
 
+<!-- start -->
+
 Compile logical circuits to lattice surgery operations on a surface code lattice and visualize.
 
 ![image](https://user-images.githubusercontent.com/36427091/104856854-98ca5600-58c9-11eb-9599-286c1d5a4736.png)
 
 ## Overview
-
-<!-- start overview -->
-
 A compiler that takes a QASM circuit and turns it into abstract lattice surgery instructions.
 
 Our long term vision is to have an end to end lattice surgery compiler. We want it to be able to take a manually programmed circuit and ouput a large error corrected circuit, that performs the same computation with many more qubits and a higher degree of accuracy.
 
-<!-- end overview -->
-
-#### Features:
+### Features:
 * Web-based patch visualizer that shows a computation happening on a surface code lattice (in picture). Try it at https://latticesurgery.com.
 * HTTP Service to compile qasm circuits
 * Data representation for Pauli rotations and abstract lattice surgery operations
 * QASM to lattice surgery patch compiler 
 * Remove sabilizer operations from the input circuit
 * Simulation of patch computations
+
+<!-- end -->
 
 ## Background 
 A proposed solution to mitigate the occurrence of errors in quantum computers are the so-called quantum error correcting codes (QECC). Specifically we focus on the protocol of lattice surgery, which is based on the prominent methodology of surface codes. A natural question relates to how these techniques can be employed to systematically obtain fault tolerant logical qubits from less reliable ones. Recent work has focused on building compilers that translate a logical quantum circuit to a much larger error corrected one, with the output circuit performing the computation specified by the logical circuit with QECCs [[1]](#1)[[2]](#2). 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+furo==2021.11.12.1
+myst-parser==0.15.2
+Sphinx==4.3.0

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -1,0 +1,5 @@
+# API Reference
+
+```{note}
+This section is still under active development
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,54 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "Lattice Surgery Compiler"
+copyright = "2021, George Watkins and Alex Nguyen"
+author = "George Watkins and Alex Nguyen"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ["myst_parser", "sphinx.ext.napoleon", "sphinx.ext.autodoc"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+# -- Options for Markdown files ----------------------------------------------
+
+myst_heading_anchors = 3
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "furo"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@
 
 project = "Lattice Surgery Compiler"
 copyright = "2021, George Watkins and Alex Nguyen"
-author = "George Watkins and Alex Nguyen"
+author = "George Watkins, Alex Nguyen and Contributors"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -1,0 +1,2 @@
+```{include} ../../CONTRIBUTING.md
+```

--- a/docs/source/guide/index.md
+++ b/docs/source/guide/index.md
@@ -1,0 +1,10 @@
+# User Guide
+
+```{note}
+This section is still under active development
+```
+
+```{toctree}
+
+setup
+```

--- a/docs/source/guide/setup.md
+++ b/docs/source/guide/setup.md
@@ -1,0 +1,5 @@
+# Setup
+
+```{note}
+This documentation is still under active development
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,0 +1,25 @@
+# Lattice Surgery Compiler
+
+```{note}
+This documentation is still under active development
+```
+
+```{include} ../../README.md
+:start-after: <!-- start overview -->
+:end-before: <!-- end overview -->
+```
+
+```{toctree}
+:caption: Main
+:hidden:
+
+guide/index
+```
+
+```{toctree}
+:caption: Development
+:hidden:
+
+api/index
+license
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,12 +1,8 @@
 # Lattice Surgery Compiler
 
-```{note}
-This documentation is still under active development
-```
-
 ```{include} ../../README.md
-:start-after: <!-- start overview -->
-:end-before: <!-- end overview -->
+:start-after: <!-- start -->
+:end-before: <!-- end -->
 ```
 
 ```{toctree}
@@ -20,6 +16,7 @@ guide/index
 :caption: Development
 :hidden:
 
+contributing
 api/index
 license
 ```

--- a/docs/source/license.md
+++ b/docs/source/license.md
@@ -1,0 +1,4 @@
+# License
+
+```{include} ../../LICENSE
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,4 @@ line-length = 100
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]


### PR DESCRIPTION
As title. Documentation is located at `docs/`. We will be using [myst-parser](https://myst-parser.readthedocs.io/en/latest/index.html) which allow us to Markdown instead of reStructuredText, as well as re-using our existing `.md` file to the documentation page. ~~Also created a automated job for testing documentation~~ switched to using ReadTheDocs build tool. Work in progress.

Note - to build on your own, use this:
```
cd docs
pip install -r requirements.txt
make html
```

Part of #115. 