### PR TITLE
Add `pauli_rotations` to API documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+    builder: html
+    configuration: docs/source/conf.py
+    fail_on_warning: true
+
+# Optionally declare the Python requirements required to build your docs
+python:
+    install:
+      - requirements: docs/requirements.txt
+      - method: pip
+        path: .

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Our long term vision is to have an end to end lattice surgery compiler. We want 
 * HTTP Service to compile qasm circuits
 * Data representation for Pauli rotations and abstract lattice surgery operations
 * QASM to lattice surgery patch compiler 
-* Remove sabilizer operations from the input circuit
+* Remove stabilizer operations from the input circuit
 * Simulation of patch computations
 
 <!-- end -->

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-furo==2021.11.12.1
 myst-parser==0.15.2
 Sphinx==4.3.0
+sphinx-autodoc-typehints==1.12.0
+sphinx-rtd-theme==1.0.0

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -3,3 +3,8 @@
 ```{note}
 This section is still under active development
 ```
+
+```{toctree}
+
+pauli_rotations
+```

--- a/docs/source/api/pauli_rotations.md
+++ b/docs/source/api/pauli_rotations.md
@@ -1,0 +1,29 @@
+# pauli_rotations
+
+```{note}
+This section is still under active development
+```
+
+```{eval-rst}
+.. autoclass:: lsqecc.pauli_rotations.PauliOpCircuit
+    :show-inheritance:
+    :members: 
+```
+
+```{eval-rst}
+.. autoclass:: lsqecc.pauli_rotations.PauliOperator
+    :show-inheritance:
+    :members: 
+```
+
+```{eval-rst}
+.. autoclass:: lsqecc.pauli_rotations.PauliRotation
+    :show-inheritance:
+    :members: 
+```
+
+```{eval-rst}
+.. autoclass:: lsqecc.pauli_rotations.Measurement
+    :show-inheritance:
+    :members: 
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,9 +10,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../src"))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,4 +57,4 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,12 @@ author = "George Watkins, Alex Nguyen and Contributors"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_parser", "sphinx.ext.napoleon", "sphinx.ext.autodoc"]
+extensions = [
+    "myst_parser",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -46,7 +51,7 @@ myst_heading_anchors = 3
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "furo"
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Changes:
* Add section for `pauli_rotations` submodule to demonstrate [Sphinx autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) usage. 
* Trying out ReadTheDocs theme - API page with Furo was hard to read for me. 
* Trying out [sphinx-autodoc-typehints](https://github.com/agronholm/sphinx-autodoc-typehints). Seems good so far. 

Also testing if CI tool skip testing for this PR. 