### PR TITLE
Add how to build docs to contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,11 @@ To run the entire testsuite:
  
 To run a particular test:
 ```pytest tests/path/to/file.py```
+
+### Building the Docs
+
+We generate docs from docstrings and `.md` files. Our CI pipeline already builds the docs and provides a preview for every PR, but you can preview the docs on you local machine by following the steps below.
+
+ 1. `cd docs` to enter the docs directory
+ 2. `pip install -r requirements.txt` to install or update the doc build dependencies
+ 3. `make clean && make htm` clean builds the docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,4 +64,4 @@ We generate docs from docstrings and `.md` files. Our CI pipeline already builds
 
  1. `cd docs` to enter the docs directory
  2. `pip install -r requirements.txt` to install or update the doc build dependencies
- 3. `make clean && make htm` clean builds the docs
+ 3. `make clean && make html` clean builds the docs


### PR DESCRIPTION
Might be nice to add a quick overview of how the docs CI was set up to the [UF Fund set up guide](https://github.com/latticesurgery-com/lattice-surgery-compiler/wiki/Unitary-Fund-Python-project-set-up-guide) as well