### PR TITLE
[BUGFIX] Product of Pauli Operators was defined wrong.

### DIFF
--- a/src/lsqecc/pauli_rotations/circuit.py
+++ b/src/lsqecc/pauli_rotations/circuit.py
@@ -224,7 +224,7 @@ class PauliOpCircuit(object):
 
             # Flip the phase if product of coefficients is negative
             # Product of coefficients will always be either i or -i (see issues #28 for proof)
-            product_of_coefficients /= 1j
+            product_of_coefficients *= 1j
             if isinstance(self.ops[next_block], Measurement):
                 if product_of_coefficients.real < 0:
                     measurement = cast(Measurement, self.ops[next_block])

--- a/src/lsqecc/pauli_rotations/rotation.py
+++ b/src/lsqecc/pauli_rotations/rotation.py
@@ -78,10 +78,10 @@ _PauliOperator_anticommute_tbl: Dict[
 ] = {
     (PauliOperator.Z, PauliOperator.X): (1j, PauliOperator.Y),
     (PauliOperator.X, PauliOperator.Z): (-1j, PauliOperator.Y),
-    (PauliOperator.Z, PauliOperator.Y): (1j, PauliOperator.X),
-    (PauliOperator.Y, PauliOperator.Z): (-1j, PauliOperator.X),
-    (PauliOperator.Y, PauliOperator.X): (1j, PauliOperator.Z),
-    (PauliOperator.X, PauliOperator.Y): (-1j, PauliOperator.Z),
+    (PauliOperator.Y, PauliOperator.Z): (1j, PauliOperator.X),
+    (PauliOperator.Z, PauliOperator.Y): (-1j, PauliOperator.X),
+    (PauliOperator.X, PauliOperator.Y): (1j, PauliOperator.Z),
+    (PauliOperator.Y, PauliOperator.X): (-1j, PauliOperator.Z),
 }
 
 

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -119,7 +119,7 @@ class TestPauliOperator:
         assert PauliOperator.multiply_operators(input, I) == (1, input)
         assert PauliOperator.multiply_operators(I, input) == (1, input)
 
-    @pytest.mark.parametrize("input, expected", [((Z, X), Y), ((Z, Y), X), ((Y, X), Z)])
+    @pytest.mark.parametrize("input, expected", [((Z, X), Y), ((Y, Z), X), ((X, Y), Z)])
     def test_multiply_operators_non_commuting(self, input, expected):
         assert PauliOperator.multiply_operators(*input) == (1j, expected)
         assert PauliOperator.multiply_operators(*reversed(input)) == (-1j, expected)


### PR DESCRIPTION
- Corrected the output of the prodcuts
- line 254 in circuit.py should be multiplication not division.
- made relevant changes to rotation.py tests