### PR TITLE
Change the implementation of `PauliProductOperation` 

### DIFF
--- a/src/lsqecc/pauli_rotations/rotation.py
+++ b/src/lsqecc/pauli_rotations/rotation.py
@@ -91,12 +91,14 @@ class PauliProductOperation(ABC):
         self.qubit_num: int = no_of_qubit
         self.ops_list: List[PauliOperator] = [PauliOperator("I") for i in range(no_of_qubit)]
 
+    @abstractmethod
     def __str__(self) -> str:
         pass
 
     def __repr__(self) -> str:
         return str(self)
 
+    @abstractmethod
     def __eq__(self, other):
         pass
 
@@ -112,7 +114,6 @@ class PauliProductOperation(ABC):
         return_str += ")"
         return return_str
 
-    @abstractmethod
     def change_single_op(self, qubit: int, new_op: PauliOperator) -> None:
         """Modify a Pauli Operator
 
@@ -126,7 +127,6 @@ class PauliProductOperation(ABC):
 
         self.ops_list[qubit] = new_op
 
-    @abstractmethod
     def get_op(self, qubit: int) -> PauliOperator:
         """Return the current operator of qubit i.
 
@@ -138,7 +138,6 @@ class PauliProductOperation(ABC):
         """
         return self.ops_list[qubit]
 
-    @abstractmethod
     def get_ops_map(self) -> Dict[int, PauliOperator]:
         """ "
         Return a map of qubit_n -> operator
@@ -193,15 +192,6 @@ class PauliRotation(PauliProductOperation, coc.ConditionalOperation):
             r.change_single_op(i, op)
         return r
 
-    def change_single_op(self, qubit: int, new_op: PauliOperator) -> None:
-        return super().change_single_op(qubit, new_op)
-
-    def get_op(self, qubit: int) -> PauliOperator:
-        return super().get_op(qubit)
-
-    def get_ops_map(self) -> Dict[int, PauliOperator]:
-        return super().get_ops_map()
-
 
 class Measurement(PauliProductOperation, coc.ConditionalOperation):
     """Representing a Pauli Product Measurement Block"""
@@ -242,12 +232,3 @@ class Measurement(PauliProductOperation, coc.ConditionalOperation):
             m.change_single_op(i, op)
 
         return m
-
-    def change_single_op(self, qubit: int, new_op: PauliOperator) -> None:
-        return super().change_single_op(qubit, new_op)
-
-    def get_op(self, qubit: int) -> PauliOperator:
-        return super().get_op(qubit)
-
-    def get_ops_map(self) -> Dict[int, PauliOperator]:
-        return super().get_ops_map()

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -19,7 +19,7 @@ from fractions import Fraction
 
 import pytest
 
-from lsqecc.pauli_rotations import Measurement, PauliOperator, PauliRotation
+from lsqecc.pauli_rotations import Measurement, PauliOperator, PauliRotation, PauliProductOperation
 
 I = PauliOperator.I  # noqa: E741
 X = PauliOperator.X
@@ -160,6 +160,11 @@ class TestPauliProductOperation:
     def test_get_ops_map(self):
         m = Measurement.from_list([X, Z, I, X, I, Z])
         assert m.get_ops_map() == {0: X, 1: Z, 3: X, 5: Z}
+
+    def test_pauli_product_op_init(self):
+        # Should not be able to initialize an instance of PauliProductOperation
+        with pytest.raises(TypeError):
+            PauliProductOperation(2)
 
 
 class TestPauliOperator:

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -19,7 +19,12 @@ from fractions import Fraction
 
 import pytest
 
-from lsqecc.pauli_rotations import Measurement, PauliOperator, PauliRotation, PauliProductOperation
+from lsqecc.pauli_rotations import (
+    Measurement,
+    PauliOperator,
+    PauliProductOperation,
+    PauliRotation,
+)
 
 I = PauliOperator.I  # noqa: E741
 X = PauliOperator.X


### PR DESCRIPTION
Made `PauliProductOperation` an [ABC class](https://docs.python.org/3.9/library/abc.html). `ConditionalOperation` mix-in is now used by `Measurement` and `PauliRotation` instead. 

~~Will need to rebase with dev to trigger automated testing again once #165 is approved and merged~~. Done