### PR TITLE
Add tests for `__str__` and `to_latex()` for Measurement and PauliRotation

### DIFF
--- a/src/lsqecc/pauli_rotations/circuit.py
+++ b/src/lsqecc/pauli_rotations/circuit.py
@@ -82,7 +82,6 @@ class PauliOpCircuit(object):
         if index is None:
             index = len(self)
 
-        # print(rotation)
         self.ops.insert(index, new_block)
 
     def add_single_operator(

--- a/src/lsqecc/pauli_rotations/rotation.py
+++ b/src/lsqecc/pauli_rotations/rotation.py
@@ -107,7 +107,7 @@ class PauliProductOperation(ABC):
 
     @abstractmethod
     def to_latex(self) -> str:
-        return_str = "(" + str(self.ops_list[0])
+        return_str = f"({self.ops_list[0]}"
         if self.qubit_num > 1:
             for i in range(1, len(self.ops_list)):
                 return_str += r" \otimes" + " " + str(self.ops_list[i])
@@ -167,7 +167,7 @@ class PauliRotation(PauliProductOperation, coc.ConditionalOperation):
         self.rotation_amount: Fraction = rotation_amount
 
     def __str__(self) -> str:
-        return "{}: {}".format(self.rotation_amount, self.ops_list)
+        return f"{self.rotation_amount}: {self.ops_list}"
 
     def __eq__(self, other) -> bool:
         return (
@@ -177,10 +177,7 @@ class PauliRotation(PauliProductOperation, coc.ConditionalOperation):
         )
 
     def to_latex(self) -> str:
-        return_str = super().to_latex()
-        return_str += "_" + phase_frac_to_latex(self.rotation_amount)
-
-        return return_str
+        return f"{super().to_latex()}_{phase_frac_to_latex(self.rotation_amount)}"
 
     @staticmethod
     def from_list(pauli_ops: List[PauliOperator], rotation: Fraction) -> "PauliRotation":
@@ -208,7 +205,8 @@ class Measurement(PauliProductOperation, coc.ConditionalOperation):
         self.isNegative: bool = isNegative
 
     def __str__(self) -> str:
-        return "{}M: {}".format("-" if self.isNegative else "", self.ops_list)
+        sign = "-" if self.isNegative else ""
+        return f"{sign}M: {self.ops_list}"
 
     def __eq__(self, other) -> bool:
         return (

--- a/src/lsqecc/pauli_rotations/rotation.py
+++ b/src/lsqecc/pauli_rotations/rotation.py
@@ -177,7 +177,7 @@ class PauliRotation(PauliProductOperation, coc.ConditionalOperation):
         )
 
     def to_latex(self) -> str:
-        return f"{super().to_latex()}_{phase_frac_to_latex(self.rotation_amount)}"
+        return f"{super().to_latex()}_{{{phase_frac_to_latex(self.rotation_amount)}}}"
 
     @staticmethod
     def from_list(pauli_ops: List[PauliOperator], rotation: Fraction) -> "PauliRotation":

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -91,6 +91,37 @@ class TestPauliRotation:
     def test_pauli_rotation_ne(self, pauli_rotation_1, pauli_rotation_2):
         assert pauli_rotation_1 != pauli_rotation_2
 
+    @pytest.mark.parametrize(
+        "input, expected",
+        [
+            (PauliRotation.from_list([Y], Fraction(1, 2)), "1/2: [Y]"),
+            (PauliRotation.from_list([I, X], Fraction(4, 2)), "2: [I, X]"),
+            (PauliRotation.from_list([Y, X], Fraction(-0, 5)), "0: [Y, X]"),
+            (PauliRotation.from_list([X, Z, Y], Fraction(-6, 8)), "-3/4: [X, Z, Y]"),
+        ],
+    )
+    def test_str(self, input, expected):
+        assert str(input) == expected
+
+    @pytest.mark.parametrize(
+        "input, expected",
+        [
+            (PauliRotation.from_list([Y], Fraction(1, 2)), r"(Y)_\frac{\pi}{2}"),
+            (PauliRotation.from_list([Z, I], Fraction(-0, 4)), r"(Z \otimes I)_0"),
+            (PauliRotation.from_list([X, Y], Fraction(-6, 3)), r"(X \otimes Y)_-2\pi"),
+            (
+                PauliRotation.from_list([Y, X, Z], Fraction(-3, 4)),
+                r"(Y \otimes X \otimes Z)_-\frac{3\pi}{4}",
+            ),
+            (
+                PauliRotation.from_list([Y, X, I, Z], Fraction(8, 6)),
+                r"(Y \otimes X \otimes I \otimes Z)_\frac{4\pi}{3}",
+            ),
+        ],
+    )
+    def test_to_latex(self, input, expected):
+        assert input.to_latex() == expected
+
 
 class TestMeasurement:
     """Tests for Measurement class"""
@@ -133,6 +164,27 @@ class TestMeasurement:
     )
     def test_measurement_ne(self, measurement_1, measurement_2):
         assert measurement_1 != measurement_2
+
+    @pytest.mark.parametrize(
+        "input, expected",
+        [
+            (Measurement.from_list([Y]), "M: [Y]"),
+            (Measurement.from_list([I, X], True), "-M: [I, X]"),
+        ],
+    )
+    def test_str(self, input, expected):
+        assert str(input) == expected
+
+    @pytest.mark.parametrize(
+        "input, expected",
+        [
+            (Measurement.from_list([Y]), "(Y)_M"),
+            (Measurement.from_list([I, X], True), r"(I \otimes X)_{-M}"),
+            (Measurement.from_list([X, Y, Z], True), r"(X \otimes Y \otimes Z)_{-M}"),
+        ],
+    )
+    def test_to_latex(self, input, expected):
+        assert input.to_latex() == expected
 
 
 class TestPauliProductOperation:

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -106,16 +106,16 @@ class TestPauliRotation:
     @pytest.mark.parametrize(
         "input, expected",
         [
-            (PauliRotation.from_list([Y], Fraction(1, 2)), r"(Y)_\frac{\pi}{2}"),
-            (PauliRotation.from_list([Z, I], Fraction(-0, 4)), r"(Z \otimes I)_0"),
-            (PauliRotation.from_list([X, Y], Fraction(-6, 3)), r"(X \otimes Y)_-2\pi"),
+            (PauliRotation.from_list([Y], Fraction(1, 2)), r"(Y)_{\frac{\pi}{2}}"),
+            (PauliRotation.from_list([Z, I], Fraction(-0, 4)), r"(Z \otimes I)_{0}"),
+            (PauliRotation.from_list([X, Y], Fraction(-6, 3)), r"(X \otimes Y)_{-2\pi}"),
             (
                 PauliRotation.from_list([Y, X, Z], Fraction(-3, 4)),
-                r"(Y \otimes X \otimes Z)_-\frac{3\pi}{4}",
+                r"(Y \otimes X \otimes Z)_{-\frac{3\pi}{4}}",
             ),
             (
                 PauliRotation.from_list([Y, X, I, Z], Fraction(8, 6)),
-                r"(Y \otimes X \otimes I \otimes Z)_\frac{4\pi}{3}",
+                r"(Y \otimes X \otimes I \otimes Z)_{\frac{4\pi}{3}}",
             ),
         ],
     )


### PR DESCRIPTION
Closes #167. Also switch to using f-string for those functions.