### PR TITLE
Add test cases for commutation

### DIFF
--- a/tests/pauli_rotations/circuit_test.py
+++ b/tests/pauli_rotations/circuit_test.py
@@ -136,3 +136,20 @@ def test_commute_rotation_measurement_commuting(rotation, measurement):
 def test_commute_rotation_measurement_anticommute():
     # TODO: Develop test cases for this test
     pass
+
+
+def test_commute_no_next_block():
+    circuit = PauliOpCircuit(1)
+    circuit.add_pauli_block(PauliRotation.from_list([X], Fraction(1, 4)))
+
+    with pytest.raises(Exception):
+        circuit.commute_pi_over_four_rotation(0)
+
+
+def test_commute_non_pi_over_4_rotation():
+    circuit = PauliOpCircuit(1)
+    circuit.add_pauli_block(PauliRotation.from_list([X], Fraction(1, 8)))
+    circuit.add_pauli_block(PauliRotation.from_list([Y], Fraction(1, 4)))
+
+    with pytest.raises(Exception):
+        circuit.commute_pi_over_four_rotation(0)

--- a/tests/pauli_rotations/circuit_test.py
+++ b/tests/pauli_rotations/circuit_test.py
@@ -75,9 +75,12 @@ def test_count_rotations_by(circuit, fraction, expected):
     ],
 )
 def test_commute_rotation_to_rotation_commuting(rotation1, rotation2):
+    # Before commuting: rotation1 ---- rotation2
     test_circuit = PauliOpCircuit(len(rotation1[0]))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation1))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation2))
+
+    # After commuting: rotation2 ---- rotation1
     test_circuit.commute_pi_over_four_rotation(0)
 
     assert test_circuit.ops[0].ops_list == rotation2[0]
@@ -87,7 +90,7 @@ def test_commute_rotation_to_rotation_commuting(rotation1, rotation2):
 
 
 @pytest.mark.parametrize(
-    "rotation1, rotation2, resultant_rotation",
+    "rotation1, rotation2, rotation2_after",
     [
         (([X], Fraction(1, 4)), ([Z], Fraction(1, 4)), ([Y], Fraction(1, 4))),
         (([Y], Fraction(-1, 4)), ([X], Fraction(-1, 8)), ([Z], Fraction(-1, 8))),
@@ -101,14 +104,17 @@ def test_commute_rotation_to_rotation_commuting(rotation1, rotation2):
         ),
     ],
 )
-def test_commute_rotation_rotation_anti_commuting(rotation1, rotation2, resultant_rotation):
+def test_commute_rotation_rotation_anti_commuting(rotation1, rotation2, rotation2_after):
+    # Before commuting: rotation1 ---- rotation2
     test_circuit = PauliOpCircuit(len(rotation1[0]))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation1))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation2))
+
+    # After commuting: rotation2_after ---- rotation1
     test_circuit.commute_pi_over_four_rotation(0)
 
-    assert test_circuit.ops[0].ops_list == resultant_rotation[0]
-    assert test_circuit.ops[0].rotation_amount == resultant_rotation[1]
+    assert test_circuit.ops[0].ops_list == rotation2_after[0]
+    assert test_circuit.ops[0].rotation_amount == rotation2_after[1]
     assert test_circuit.ops[1].ops_list == rotation1[0]
     assert test_circuit.ops[1].rotation_amount == rotation1[1]
 
@@ -123,9 +129,12 @@ def test_commute_rotation_rotation_anti_commuting(rotation1, rotation2, resultan
     ],
 )
 def test_commute_rotation_measurement_commuting(rotation, measurement):
+    # Before commuting: rotation ---- measurement
     test_circuit = PauliOpCircuit(len(rotation[0]))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation))
     test_circuit.add_pauli_block(Measurement.from_list(*measurement))
+
+    # After commuting: measurement ---- rotation
     test_circuit.commute_pi_over_four_rotation(0)
 
     assert test_circuit.ops[0].ops_list == measurement[0]
@@ -135,7 +144,7 @@ def test_commute_rotation_measurement_commuting(rotation, measurement):
 
 
 @pytest.mark.parametrize(
-    "rotation, measurement, resultant_measurement",
+    "rotation, measurement, measurement_after",
     [
         (([X], Fraction(1, 4)), ([Z], False), ([Y], False)),
         (([Y], Fraction(-1, 4)), ([X], True), ([Z], True)),
@@ -149,14 +158,17 @@ def test_commute_rotation_measurement_commuting(rotation, measurement):
         ),
     ],
 )
-def test_commute_rotation_measurement_anticommute(rotation, measurement, resultant_measurement):
+def test_commute_rotation_measurement_anticommute(rotation, measurement, measurement_after):
+    # Before commuting: rotation ---- measurement
     test_circuit = PauliOpCircuit(len(rotation[0]))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation))
     test_circuit.add_pauli_block(Measurement.from_list(*measurement))
+
+    # After commuting: measurement_after ---- rotation
     test_circuit.commute_pi_over_four_rotation(0)
 
-    assert test_circuit.ops[0].ops_list == resultant_measurement[0]
-    assert test_circuit.ops[0].isNegative == resultant_measurement[1]
+    assert test_circuit.ops[0].ops_list == measurement_after[0]
+    assert test_circuit.ops[0].isNegative == measurement_after[1]
     assert test_circuit.ops[1].ops_list == rotation[0]
     assert test_circuit.ops[1].rotation_amount == rotation[1]
 

--- a/tests/pauli_rotations/circuit_test.py
+++ b/tests/pauli_rotations/circuit_test.py
@@ -1,6 +1,9 @@
+from fractions import Fraction
+
 import pytest
 
-from lsqecc.pauli_rotations.circuit import PauliOpCircuit
+from lsqecc.pauli_rotations.circuit import PauliOpCircuit, PauliOperator, PauliRotation
+from lsqecc.pauli_rotations.rotation import Measurement
 
 from .generate_tests_circuit import (
     generate_tests_are_commuting,
@@ -10,6 +13,11 @@ from .generate_tests_circuit import (
     generate_tests_join_same_qubit_num,
     generate_tests_pauli_op_circuit_equality,
 )
+
+I = PauliOperator.I  # noqa: E741
+X = PauliOperator.X
+Y = PauliOperator.Y
+Z = PauliOperator.Z
 
 
 @pytest.mark.parametrize(
@@ -57,6 +65,74 @@ def test_count_rotations_by(circuit, fraction, expected):
     assert circuit.count_rotations_by(fraction) == expected
 
 
-# def test_remove_y_operators_from_circuit(output, expected):
-#     raise NotImplementedError
-#     # assert output == expected
+@pytest.mark.parametrize(
+    "rotation1, rotation2",
+    [
+        (([X], Fraction(1, 4)), ([I], Fraction(1, 4))),
+        (([I, X], Fraction(1, 4)), ([Y, X], Fraction(-1, 8))),
+        (([X, Z, Y], Fraction(1, 4)), ([Y, X, Y], Fraction(1, 8))),
+        (([I, Z, I, X], Fraction(-1, 4)), ([Z, X, I, Z], Fraction(-1, 8))),
+    ],
+)
+def test_commute_rotation_to_rotation_commuting(rotation1, rotation2):
+    test_circuit = PauliOpCircuit(len(rotation1[0]))
+    test_circuit.add_pauli_block(PauliRotation.from_list(*rotation1))
+    test_circuit.add_pauli_block(PauliRotation.from_list(*rotation2))
+    test_circuit.commute_pi_over_four_rotation(0)
+
+    assert test_circuit.ops[0].ops_list == rotation2[0]
+    assert test_circuit.ops[0].rotation_amount == rotation2[1]
+    assert test_circuit.ops[1].ops_list == rotation1[0]
+    assert test_circuit.ops[1].rotation_amount == rotation1[1]
+
+
+@pytest.mark.parametrize(
+    "rotation1, rotation2, resultant_rotation",
+    [
+        (([X], Fraction(1, 4)), ([Z], Fraction(1, 4)), ([Y], Fraction(1, 4))),
+        (([Y], Fraction(1, 4)), ([X], Fraction(-1, 8)), ([Z], Fraction(-1, 8))),
+        (([Z, X], Fraction(1, 4)), ([Y, X], Fraction(1, 8)), ([X, I], Fraction(1, 8))),
+        (([X, Z, Y], Fraction(1, 4)), ([Y, X, Z], Fraction(-1, 8)), ([Z, Y, X], Fraction(-1, 8))),
+        (
+            ([X, Y, X, Z, Z], Fraction(1, 4)),
+            ([Z, Y, I, X, Y], Fraction(1, 8)),
+            ([Y, I, X, Y, X], Fraction(1, 8)),
+        ),
+    ],
+)
+def test_commute_rotation_rotation_anti_commuting(rotation1, rotation2, resultant_rotation):
+    test_circuit = PauliOpCircuit(len(rotation1[0]))
+    test_circuit.add_pauli_block(PauliRotation.from_list(*rotation1))
+    test_circuit.add_pauli_block(PauliRotation.from_list(*rotation2))
+    test_circuit.commute_pi_over_four_rotation(0)
+
+    assert test_circuit.ops[0].ops_list == resultant_rotation[0]
+    assert test_circuit.ops[0].rotation_amount == resultant_rotation[1]
+    assert test_circuit.ops[1].ops_list == rotation1[0]
+    assert test_circuit.ops[1].rotation_amount == rotation1[1]
+
+
+@pytest.mark.parametrize(
+    "rotation, measurement",
+    [
+        (([X], Fraction(1, 4)), ([I], False)),
+        (([I, X], Fraction(1, 4)), ([Y, X], True)),
+        (([X, Z, Y], Fraction(1, 4)), ([Y, X, Y], False)),
+        (([I, Z, I, X], Fraction(-1, 4)), ([Z, X, I, Z], True)),
+    ],
+)
+def test_commute_rotation_measurement_commuting(rotation, measurement):
+    test_circuit = PauliOpCircuit(len(rotation[0]))
+    test_circuit.add_pauli_block(PauliRotation.from_list(*rotation))
+    test_circuit.add_pauli_block(Measurement.from_list(*measurement))
+    test_circuit.commute_pi_over_four_rotation(0)
+
+    assert test_circuit.ops[0].ops_list == measurement[0]
+    assert test_circuit.ops[0].isNegative == measurement[1]
+    assert test_circuit.ops[1].ops_list == rotation[0]
+    assert test_circuit.ops[1].rotation_amount == rotation[1]
+
+
+def test_commute_rotation_measurement_anticommute():
+    # TODO: Develop test cases for this test
+    pass


### PR DESCRIPTION
Work in progress. Currently missing test cases for commuting Pauli rotation over a measurement block. 

Need reviews for test cases.

Part of #156 