### PR TITLE
refactoring commute_pi_over_four_rotation

### DIFF
--- a/src/lsqecc/pauli_rotations/circuit.py
+++ b/src/lsqecc/pauli_rotations/circuit.py
@@ -191,7 +191,7 @@ class PauliOpCircuit(object):
 
             i += 1
 
-    def __swap_adjacent_commuting_blocks(self, index: int) -> None:
+    def _swap_adjacent_commuting_blocks(self, index: int) -> None:
         """
         Move a pi over four rotation block past its' neighbor block when the blocks commute
 
@@ -203,7 +203,7 @@ class PauliOpCircuit(object):
         self.ops[index] = self.ops[next_block]
         self.ops[next_block] = temp
 
-    def __swap_adjacent_anticommuting_blocks(self, index: int) -> None:
+    def _swap_adjacent_anticommuting_blocks(self, index: int) -> None:
         """
         Move a pi over four rotation block past its' neighbor block when the blocks anti-commute
 
@@ -257,9 +257,11 @@ class PauliOpCircuit(object):
             raise Exception("First operand must be +-pi/4 Pauli rotation")
 
         if not PauliOpCircuit.are_commuting(self.ops[index], self.ops[next_block]):
-            self.__swap_adjacent_anticommuting_blocks(index)
+            self._swap_adjacent_anticommuting_blocks(index)
+        elif PauliOpCircuit.are_commuting(self.ops[index], self.ops[next_block]):
+            self._swap_adjacent_commuting_blocks(index)
         else:
-            self.__swap_adjacent_commuting_blocks(index)
+            raise Exception("The two blocks must commute or anti-commute!")
 
     def circuit_has_measurements(self) -> bool:
         """Check if circuit has any Measurement blocks.

--- a/src/lsqecc/pauli_rotations/circuit.py
+++ b/src/lsqecc/pauli_rotations/circuit.py
@@ -199,6 +199,9 @@ class PauliOpCircuit(object):
             index (int): Index of the targeted block in the current circuit
         """
         next_block = index + 1
+        if not PauliOpCircuit.are_commuting(self.ops[index], self.ops[next_block]):
+            raise Exception("The blocks to be swapped must commute!")
+
         temp = self.ops[index]
         self.ops[index] = self.ops[next_block]
         self.ops[next_block] = temp
@@ -212,6 +215,9 @@ class PauliOpCircuit(object):
 
         """
         next_block = index + 1
+        if PauliOpCircuit.are_commuting(self.ops[index], self.ops[next_block]):
+            raise Exception("The blocks to be swapped must anti-commute!")
+
         product_of_coefficients = complex(1)
 
         for i in range(self.qubit_num):
@@ -258,10 +264,8 @@ class PauliOpCircuit(object):
 
         if not PauliOpCircuit.are_commuting(self.ops[index], self.ops[next_block]):
             self._swap_adjacent_anticommuting_blocks(index)
-        elif PauliOpCircuit.are_commuting(self.ops[index], self.ops[next_block]):
-            self._swap_adjacent_commuting_blocks(index)
         else:
-            raise Exception("The two blocks must commute or anti-commute!")
+            self._swap_adjacent_commuting_blocks(index)
 
     def circuit_has_measurements(self) -> bool:
         """Check if circuit has any Measurement blocks.

--- a/src/lsqecc/pauli_rotations/circuit.py
+++ b/src/lsqecc/pauli_rotations/circuit.py
@@ -127,7 +127,7 @@ class PauliOpCircuit(object):
         while quarter_rotation:
             index = quarter_rotation.pop()
             while index + 1 < len(self):
-                self.commute_pi_over_four_rotation(index)
+                self.swap_adjacent_blocks(index)
                 index += 1
             if circuit_has_measurements:
                 self.ops.pop()
@@ -180,7 +180,7 @@ class PauliOpCircuit(object):
                     # Commute the right (new) pi/4 rotations towards the end of the circuit
                     for right_block_index in right_block_indices:
                         while right_block_index + 1 < len(self.ops):
-                            self.commute_pi_over_four_rotation(right_block_index)
+                            self.swap_adjacent_blocks(right_block_index)
                             right_block_index += 1
                         if circuit_has_measurements:
                             self.ops.pop()
@@ -191,15 +191,62 @@ class PauliOpCircuit(object):
 
             i += 1
 
-    def commute_pi_over_four_rotation(self, index: int) -> None:
-        """Commute a rotation block pass its neighbor block.
+    def __swap_adjacent_commuting_blocks(self, index: int) -> None:
+        """
+        Move a pi over four rotation block past its' neighbor block when the blocks commute
 
         Args:
-            index (int): Index of the targeted block in the current circuit.
+            index (int): Index of the targeted block in the current circuit
+        """
+        next_block = index + 1
+        temp = self.ops[index]
+        self.ops[index] = self.ops[next_block]
+        self.ops[next_block] = temp
+
+    def __swap_adjacent_anticommuting_blocks(self, index: int) -> None:
+        """
+        Move a pi over four rotation block past its' neighbor block when the blocks anti-commute
+
+        Args:
+            index (int): Index of the targeted block in the current circuit
 
         """
         next_block = index + 1
+        product_of_coefficients = complex(1)
 
+        for i in range(self.qubit_num):
+            new_op = PauliOperator.multiply_operators(
+                self.ops[index].get_op(i), self.ops[next_block].get_op(i)
+            )
+
+            self.ops[next_block].change_single_op(i, new_op[1])
+            product_of_coefficients *= new_op[0]
+
+        # Flip the phase if product of coefficients is negative
+        # Product of coefficients will always be either i or -i (see issues #28 for proof)
+        product_of_coefficients *= 1j
+        if isinstance(self.ops[next_block], Measurement):
+            if product_of_coefficients.real < 0:
+                measurement = cast(Measurement, self.ops[next_block])
+                measurement.isNegative = not measurement.isNegative
+
+        else:
+            cast(PauliRotation, self.ops[next_block]).rotation_amount *= (
+                -1 if product_of_coefficients.real < 0 else 1
+            )
+
+        temp = self.ops[index]
+        self.ops[index] = self.ops[next_block]
+        self.ops[next_block] = temp
+
+    def swap_adjacent_blocks(self, index: int) -> None:
+        """
+        Move a pi over four rotation block past its' neighbor block
+
+        Args:
+            index (int): Index of the targeted block in the current circuit
+        """
+        next_block = index + 1
         if next_block >= len(self.ops):
             raise Exception("No operation to commute past")
 
@@ -209,35 +256,10 @@ class PauliOpCircuit(object):
         }:
             raise Exception("First operand must be +-pi/4 Pauli rotation")
 
-        # Need to calculate iPP' when PP' = -P'P (anti-commute)
         if not PauliOpCircuit.are_commuting(self.ops[index], self.ops[next_block]):
-            product_of_coefficients = complex(1)
-
-            for i in range(self.qubit_num):
-                new_op = PauliOperator.multiply_operators(
-                    self.ops[index].get_op(i), self.ops[next_block].get_op(i)
-                )
-
-                self.ops[next_block].change_single_op(i, new_op[1])
-                product_of_coefficients *= new_op[0]
-
-            # Flip the phase if product of coefficients is negative
-            # Product of coefficients will always be either i or -i (see issues #28 for proof)
-            product_of_coefficients *= 1j
-            if isinstance(self.ops[next_block], Measurement):
-                if product_of_coefficients.real < 0:
-                    measurement = cast(Measurement, self.ops[next_block])
-                    measurement.isNegative = not measurement.isNegative
-
-            else:
-                cast(PauliRotation, self.ops[next_block]).rotation_amount *= (
-                    -1 if product_of_coefficients.real < 0 else 1
-                )
-
-        temp = self.ops[index]
-        self.ops[index] = self.ops[next_block]
-        self.ops[next_block] = temp
-        # print(self.render_ascii())
+            self.__swap_adjacent_anticommuting_blocks(index)
+        else:
+            self.__swap_adjacent_commuting_blocks(index)
 
     def circuit_has_measurements(self) -> bool:
         """Check if circuit has any Measurement blocks.

--- a/tests/pauli_rotations/circuit_test.py
+++ b/tests/pauli_rotations/circuit_test.py
@@ -173,6 +173,42 @@ def test_swap_rotation_measurement_anticommute(rotation, measurement, measuremen
     assert test_circuit.ops[1].rotation_amount == rotation[1]
 
 
+@pytest.mark.parametrize(
+    "block1, block2",
+    [
+        (([X], Fraction(1, 4)), ([Z], False)),
+        (([Y], Fraction(-1, 4)), ([X], True)),
+        (([Z, X], Fraction(-1, 4)), ([Y, X], Fraction(1, 2))),
+        (([X, Z, Y], Fraction(1, 4)), ([Y, X, Z], Fraction(1, 2))),
+    ],
+)
+def test_swap_commute_exception(block1, block2):
+    test_circuit = PauliOpCircuit(len(block1[0]))
+    test_circuit.add_pauli_block(PauliRotation.from_list(*block1))
+    test_circuit.add_pauli_block(Measurement.from_list(*block2))
+
+    with pytest.raises(Exception):
+        test_circuit._swap_adjacent_commuting_blocks(0)
+
+
+@pytest.mark.parametrize(
+    "block1, block2",
+    [
+        (([X], Fraction(1, 4)), ([I], Fraction(1, 4))),
+        (([I, X], Fraction(1, 4)), ([Y, X], Fraction(-1, 8))),
+        (([X, Z, Y], Fraction(1, 4)), ([Y, X, Y], False)),
+        (([I, Z, I, X], Fraction(-1, 4)), ([Z, X, I, Z], True)),
+    ],
+)
+def test_swap_anticommute_exception(block1, block2):
+    test_circuit = PauliOpCircuit(len(block1[0]))
+    test_circuit.add_pauli_block(PauliRotation.from_list(*block1))
+    test_circuit.add_pauli_block(Measurement.from_list(*block2))
+
+    with pytest.raises(Exception):
+        test_circuit._swap_adjacent_anticommuting_blocks(0)
+
+
 def test_swap_no_next_block():
     circuit = PauliOpCircuit(1)
     circuit.add_pauli_block(PauliRotation.from_list([X], Fraction(1, 4)))

--- a/tests/pauli_rotations/circuit_test.py
+++ b/tests/pauli_rotations/circuit_test.py
@@ -74,14 +74,14 @@ def test_count_rotations_by(circuit, fraction, expected):
         (([I, Z, I, X], Fraction(-1, 4)), ([Z, X, I, Z], Fraction(-1, 8))),
     ],
 )
-def test_commute_rotation_to_rotation_commuting(rotation1, rotation2):
+def test_swap_rotation_to_rotation_commuting(rotation1, rotation2):
     # Before commuting: rotation1 ---- rotation2
     test_circuit = PauliOpCircuit(len(rotation1[0]))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation1))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation2))
 
     # After commuting: rotation2 ---- rotation1
-    test_circuit.commute_pi_over_four_rotation(0)
+    test_circuit.swap_adjacent_blocks(0)
 
     assert test_circuit.ops[0].ops_list == rotation2[0]
     assert test_circuit.ops[0].rotation_amount == rotation2[1]
@@ -104,14 +104,14 @@ def test_commute_rotation_to_rotation_commuting(rotation1, rotation2):
         ),
     ],
 )
-def test_commute_rotation_rotation_anti_commuting(rotation1, rotation2, rotation2_after):
+def test_swap_rotation_rotation_anti_commuting(rotation1, rotation2, rotation2_after):
     # Before commuting: rotation1 ---- rotation2
     test_circuit = PauliOpCircuit(len(rotation1[0]))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation1))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation2))
 
     # After commuting: rotation2_after ---- rotation1
-    test_circuit.commute_pi_over_four_rotation(0)
+    test_circuit.swap_adjacent_blocks(0)
 
     assert test_circuit.ops[0].ops_list == rotation2_after[0]
     assert test_circuit.ops[0].rotation_amount == rotation2_after[1]
@@ -128,14 +128,14 @@ def test_commute_rotation_rotation_anti_commuting(rotation1, rotation2, rotation
         (([I, Z, I, X], Fraction(-1, 4)), ([Z, X, I, Z], True)),
     ],
 )
-def test_commute_rotation_measurement_commuting(rotation, measurement):
+def test_swap_rotation_measurement_commuting(rotation, measurement):
     # Before commuting: rotation ---- measurement
     test_circuit = PauliOpCircuit(len(rotation[0]))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation))
     test_circuit.add_pauli_block(Measurement.from_list(*measurement))
 
     # After commuting: measurement ---- rotation
-    test_circuit.commute_pi_over_four_rotation(0)
+    test_circuit.swap_adjacent_blocks(0)
 
     assert test_circuit.ops[0].ops_list == measurement[0]
     assert test_circuit.ops[0].isNegative == measurement[1]
@@ -158,14 +158,14 @@ def test_commute_rotation_measurement_commuting(rotation, measurement):
         ),
     ],
 )
-def test_commute_rotation_measurement_anticommute(rotation, measurement, measurement_after):
+def test_swap_rotation_measurement_anticommute(rotation, measurement, measurement_after):
     # Before commuting: rotation ---- measurement
     test_circuit = PauliOpCircuit(len(rotation[0]))
     test_circuit.add_pauli_block(PauliRotation.from_list(*rotation))
     test_circuit.add_pauli_block(Measurement.from_list(*measurement))
 
     # After commuting: measurement_after ---- rotation
-    test_circuit.commute_pi_over_four_rotation(0)
+    test_circuit.swap_adjacent_blocks(0)
 
     assert test_circuit.ops[0].ops_list == measurement_after[0]
     assert test_circuit.ops[0].isNegative == measurement_after[1]
@@ -173,18 +173,18 @@ def test_commute_rotation_measurement_anticommute(rotation, measurement, measure
     assert test_circuit.ops[1].rotation_amount == rotation[1]
 
 
-def test_commute_no_next_block():
+def test_swap_no_next_block():
     circuit = PauliOpCircuit(1)
     circuit.add_pauli_block(PauliRotation.from_list([X], Fraction(1, 4)))
 
     with pytest.raises(Exception):
-        circuit.commute_pi_over_four_rotation(0)
+        circuit.swap_adjacent_blocks(0)
 
 
-def test_commute_non_pi_over_4_rotation():
+def test_swap_non_pi_over_4_rotation():
     circuit = PauliOpCircuit(1)
     circuit.add_pauli_block(PauliRotation.from_list([X], Fraction(1, 8)))
     circuit.add_pauli_block(PauliRotation.from_list([Y], Fraction(1, 4)))
 
     with pytest.raises(Exception):
-        circuit.commute_pi_over_four_rotation(0)
+        circuit.swap_adjacent_blocks(0)


### PR DESCRIPTION
- The function `commute_pi_over_four_rotation` is redefined as `swap_adajcent_blocks`
- This method calls two private methods `__swap_adjacent_commuting_blocks` and `__swap_adjacent_anticommuting_blocks`
