### PR TITLE
Refactoring `remove_y_operators_from_circuit`

### DIFF
--- a/debug/debug_litinski_transform_takes_up_space.py
+++ b/debug/debug_litinski_transform_takes_up_space.py
@@ -23,5 +23,5 @@ if __name__ == "__main__":
     print(c.render_ascii())
 
     print("Removed y operators:")
-    c.remove_y_operators_from_circuit()
+    c = c.remove_y_operators_from_circuit()
     print(c.render_ascii())

--- a/debug/debug_litinski_transform_takes_up_space.py
+++ b/debug/debug_litinski_transform_takes_up_space.py
@@ -23,5 +23,5 @@ if __name__ == "__main__":
     print(c.render_ascii())
 
     print("Removed y operators:")
-    c = c.remove_y_operators_from_circuit()
+    c = c.get_y_free_equivalent()
     print(c.render_ascii())

--- a/src/lsqecc/pauli_rotations/circuit.py
+++ b/src/lsqecc/pauli_rotations/circuit.py
@@ -126,7 +126,7 @@ class PauliOpCircuit(object):
             if circuit_has_measurements:
                 self.ops.pop()
 
-    def remove_y_operators_from_circuit(self) -> "PauliOpCircuit":
+    def get_y_free_equivalent(self) -> "PauliOpCircuit":
         """Return a Y-operator-free copy of the current circuit."""
         y_free_circuit = PauliOpCircuit(self.qubit_num, self.name)
 

--- a/src/lsqecc/pauli_rotations/rotation.py
+++ b/src/lsqecc/pauli_rotations/rotation.py
@@ -231,10 +231,8 @@ class PauliRotation(PauliProductOperation, coc.ConditionalOperation):
 
     def get_y_free_equivalent(self) -> List["PauliRotation"]:
         """Return the equivalent of current Pauli Rotation but without Y operator.
-        Only supports pi/8 rotations at the moment.
+        Supports all rotations.
         """
-        if self.rotation_amount not in (Fraction(1, 8), Fraction(-1, 8)):
-            raise NotImplementedError("Method only supports pi/8 rotations")
 
         return super().get_y_free_equivalent()
 

--- a/src/lsqecc/pipeline/lattice_surgery_compilation_pipeline.py
+++ b/src/lsqecc/pipeline/lattice_surgery_compilation_pipeline.py
@@ -58,11 +58,11 @@ def compile_str(
     compilation_text += input_circuit.render_ascii()
 
     # TODO add user flag
-    input_circuit = input_circuit.remove_y_operators_from_circuit()
+    input_circuit = input_circuit.get_y_free_equivalent()
 
     if apply_litinski_transform:
         input_circuit.apply_transformation()
-        input_circuit = input_circuit.remove_y_operators_from_circuit()
+        input_circuit = input_circuit.get_y_free_equivalent()
         compilation_text += "\nCircuit after the Litinski Transform:\n"
         compilation_text += input_circuit.render_ascii()
 

--- a/src/lsqecc/pipeline/lattice_surgery_compilation_pipeline.py
+++ b/src/lsqecc/pipeline/lattice_surgery_compilation_pipeline.py
@@ -57,9 +57,12 @@ def compile_str(
     compilation_text += "\nCircuit as Pauli rotations:\n"
     compilation_text += input_circuit.render_ascii()
 
+    # TODO add user flag
+    input_circuit = input_circuit.remove_y_operators_from_circuit()
+
     if apply_litinski_transform:
         input_circuit.apply_transformation()
-        input_circuit.remove_y_operators_from_circuit()
+        input_circuit = input_circuit.remove_y_operators_from_circuit()
         compilation_text += "\nCircuit after the Litinski Transform:\n"
         compilation_text += input_circuit.render_ascii()
 

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -32,16 +32,14 @@ Y = PauliOperator.Y
 Z = PauliOperator.Z
 
 
-def test_cases_remove_y_operators():
+def test_cases_get_y_free_equivalent():
     # TODO: Add more cases here
     case_1 = (
         PauliRotation.from_list([Y, I, Y, Z, Y, Y], Fraction(1, 8)),
-        PauliRotation.from_list([X, I, X, Z, X, X], Fraction(1, 8)),
         [
             PauliRotation.from_list([Z, I, I, I, I, I], Fraction(1, 4)),
             PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(1, 4)),
-        ],
-        [
+            PauliRotation.from_list([X, I, X, Z, X, X], Fraction(1, 8)),
             PauliRotation.from_list([Z, I, I, I, I, I], Fraction(-1, 4)),
             PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(-1, 4)),
         ],
@@ -49,9 +47,11 @@ def test_cases_remove_y_operators():
 
     case_2 = (
         PauliRotation.from_list([Y, Y, Y, Z], Fraction(1, 8)),
-        PauliRotation.from_list([X, X, X, Z], Fraction(1, 8)),
-        [PauliRotation.from_list([Z, Z, Z, I], Fraction(1, 4))],
-        [PauliRotation.from_list([Z, Z, Z, I], Fraction(-1, 4))],
+        [
+            PauliRotation.from_list([Z, Z, Z, I], Fraction(1, 4)),
+            PauliRotation.from_list([X, X, X, Z], Fraction(1, 8)),
+            PauliRotation.from_list([Z, Z, Z, I], Fraction(-1, 4)),
+        ],
     )
 
     return [case_1, case_2]
@@ -171,20 +171,18 @@ class TestPauliRotation:
     def test_to_latex(self, input, expected):
         assert input.to_latex() == expected
 
-    def test_remove_y_operator_not_pi_8(self):
+    def test_get_y_free_equivalent_not_pi_8(self):
         r = PauliRotation.from_list([I, X, Y, Z, Y], Fraction(1, 4))
         with pytest.raises(NotImplementedError):
-            r.remove_y_operators()
+            r.get_y_free_equivalent()
 
-    def test_remove_y_operators_no_y_op(self):
+    def test_get_y_free_equivalent_no_y_op(self):
         r = PauliRotation.from_list([X, Z, I, Z], Fraction(1, 8))
-        assert r.remove_y_operators() == ([], [])
-        assert r.ops_list == [X, Z, I, Z]
+        assert r.get_y_free_equivalent() == [r]
 
-    @pytest.mark.parametrize("rotation, new_rotation, lhs, rhs", test_cases_remove_y_operators())
-    def test_remove_y_operators_1(self, rotation, new_rotation, lhs, rhs):
-        assert rotation.remove_y_operators() == (lhs, rhs)
-        assert rotation == new_rotation
+    @pytest.mark.parametrize("input_rotation, output", test_cases_get_y_free_equivalent())
+    def test_get_y_free_equivalent(self, input_rotation, output):
+        assert input_rotation.get_y_free_equivalent() == output
 
 
 class TestMeasurement:

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -32,7 +32,7 @@ Y = PauliOperator.Y
 Z = PauliOperator.Z
 
 
-def test_cases_get_y_free_equivalent():
+def test_cases_get_y_free_equivalent_rotations():
     # TODO: Add more cases here
     case_1 = (
         PauliRotation.from_list([Y, I, Y, Z, Y, Y], Fraction(1, 8)),
@@ -44,8 +44,17 @@ def test_cases_get_y_free_equivalent():
             PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(-1, 4)),
         ],
     )
-
     case_2 = (
+        PauliRotation.from_list([Y, I, Y, Z, Y, Y], Fraction(1, 2)),
+        [
+            PauliRotation.from_list([Z, I, I, I, I, I], Fraction(1, 4)),
+            PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(1, 4)),
+            PauliRotation.from_list([X, I, X, Z, X, X], Fraction(1, 2)),
+            PauliRotation.from_list([Z, I, I, I, I, I], Fraction(-1, 4)),
+            PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(-1, 4)),
+        ],
+    )
+    case_3 = (
         PauliRotation.from_list([Y, Y, Y, Z], Fraction(1, 8)),
         [
             PauliRotation.from_list([Z, Z, Z, I], Fraction(1, 4)),
@@ -53,8 +62,16 @@ def test_cases_get_y_free_equivalent():
             PauliRotation.from_list([Z, Z, Z, I], Fraction(-1, 4)),
         ],
     )
+    case_4 = (
+        PauliRotation.from_list([Y, Y, Y, Z], Fraction(-1, 4)),
+        [
+            PauliRotation.from_list([Z, Z, Z, I], Fraction(1, 4)),
+            PauliRotation.from_list([X, X, X, Z], Fraction(-1, 4)),
+            PauliRotation.from_list([Z, Z, Z, I], Fraction(-1, 4)),
+        ],
+    )
 
-    return [case_1, case_2]
+    return [case_1, case_2, case_3, case_4]
 
 
 class TestPauliRotation:
@@ -171,18 +188,37 @@ class TestPauliRotation:
     def test_to_latex(self, input, expected):
         assert input.to_latex() == expected
 
-    def test_get_y_free_equivalent_not_pi_8(self):
-        r = PauliRotation.from_list([I, X, Y, Z, Y], Fraction(1, 4))
-        with pytest.raises(NotImplementedError):
-            r.get_y_free_equivalent()
-
     def test_get_y_free_equivalent_no_y_op(self):
         r = PauliRotation.from_list([X, Z, I, Z], Fraction(1, 8))
         assert r.get_y_free_equivalent() == [r]
 
-    @pytest.mark.parametrize("input_rotation, output", test_cases_get_y_free_equivalent())
+    @pytest.mark.parametrize("input_rotation, output", test_cases_get_y_free_equivalent_rotations())
     def test_get_y_free_equivalent(self, input_rotation, output):
         assert input_rotation.get_y_free_equivalent() == output
+
+
+def test_cases_get_y_free_equivalent_measurements():
+    # TODO: Add more cases here
+    case_1 = (
+        Measurement.from_list([Y, I, Y, Z, Y, Y], isNegative=False),
+        [
+            PauliRotation.from_list([Z, I, I, I, I, I], Fraction(1, 4)),
+            PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(1, 4)),
+            Measurement.from_list([X, I, X, Z, X, X], isNegative=False),
+            PauliRotation.from_list([Z, I, I, I, I, I], Fraction(-1, 4)),
+            PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(-1, 4)),
+        ],
+    )
+    case_2 = (
+        Measurement.from_list([Y, Y, Y, Z], isNegative=True),
+        [
+            PauliRotation.from_list([Z, Z, Z, I], Fraction(1, 4)),
+            Measurement.from_list([X, X, X, Z], isNegative=True),
+            PauliRotation.from_list([Z, Z, Z, I], Fraction(-1, 4)),
+        ],
+    )
+
+    return [case_1, case_2]
 
 
 class TestMeasurement:
@@ -271,6 +307,16 @@ class TestMeasurement:
     )
     def test_to_latex(self, input, expected):
         assert input.to_latex() == expected
+
+    def test_get_y_free_equivalent_no_y_op(self):
+        m = Measurement.from_list([X, Z, I, Z], isNegative=False)
+        assert m.get_y_free_equivalent() == [m]
+
+    @pytest.mark.parametrize(
+        "input_rotation, output", test_cases_get_y_free_equivalent_measurements()
+    )
+    def test_get_y_free_equivalent(self, input_rotation, output):
+        assert input_rotation.get_y_free_equivalent() == output
 
 
 class TestPauliProductOperation:

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -32,6 +32,31 @@ Y = PauliOperator.Y
 Z = PauliOperator.Z
 
 
+def test_cases_remove_y_operators():
+    # TODO: Add more cases here
+    case_1 = (
+        PauliRotation.from_list([Y, I, Y, Z, Y, Y], Fraction(1, 8)),
+        PauliRotation.from_list([X, I, X, Z, X, X], Fraction(1, 8)),
+        [
+            PauliRotation.from_list([Z, I, I, I, I, I], Fraction(1, 4)),
+            PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(1, 4)),
+        ],
+        [
+            PauliRotation.from_list([Z, I, I, I, I, I], Fraction(-1, 4)),
+            PauliRotation.from_list([I, I, Z, I, Z, Z], Fraction(-1, 4)),
+        ],
+    )
+
+    case_2 = (
+        PauliRotation.from_list([Y, Y, Y, Z], Fraction(1, 8)),
+        PauliRotation.from_list([X, X, X, Z], Fraction(1, 8)),
+        [PauliRotation.from_list([Z, Z, Z, I], Fraction(1, 4))],
+        [PauliRotation.from_list([Z, Z, Z, I], Fraction(-1, 4))],
+    )
+
+    return [case_1, case_2]
+
+
 class TestPauliRotation:
     """Tests for PauliRotation"""
 
@@ -145,6 +170,21 @@ class TestPauliRotation:
     )
     def test_to_latex(self, input, expected):
         assert input.to_latex() == expected
+
+    def test_remove_y_operator_not_pi_8(self):
+        r = PauliRotation.from_list([I, X, Y, Z, Y], Fraction(1, 4))
+        with pytest.raises(NotImplementedError):
+            r.remove_y_operators()
+
+    def test_remove_y_operators_no_y_op(self):
+        r = PauliRotation.from_list([X, Z, I, Z], Fraction(1, 8))
+        assert r.remove_y_operators() == ([], [])
+        assert r.ops_list == [X, Z, I, Z]
+
+    @pytest.mark.parametrize("rotation, new_rotation, lhs, rhs", test_cases_remove_y_operators())
+    def test_remove_y_operators_1(self, rotation, new_rotation, lhs, rhs):
+        assert rotation.remove_y_operators() == (lhs, rhs)
+        assert rotation == new_rotation
 
 
 class TestMeasurement:


### PR DESCRIPTION
Closes #184 

Currently still in progress but just want to get the PR out so we can discuss it:
* Move the Y operator removing logic to `PauliRotation`. Looking into circuit.py seems like we are only using this for pi/8 rotations, so I am keeping that. 
* Add some test cases (taken from #35). However we might want to add more (I am wondering whether the current behavior is consistent with -pi/8 rotations).