### PR TITLE
Convert opflow imports from aqua to qiskit core

### DIFF
--- a/debug/debug_state_separator.py
+++ b/debug/debug_state_separator.py
@@ -9,7 +9,7 @@ from qiskit_opflow_utils import StateSeparator
 import webgui.lattice_view
 from fractions import Fraction
 
-import qiskit.opflow as qk
+import qiskit.opflow as qkop
 import qiskit.quantum_info as qkinfo
 
 import math
@@ -18,20 +18,20 @@ import math
 
 if __name__ == "__main__":
     if len(sys.argv)>1 and sys.argv[1] == 'debug_trace':
-        state = qk.DictStateFn({'10': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
+        state = qkop.DictStateFn({'10': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
         l = [StateSeparator.trace_dict_state(state,[0]),StateSeparator.trace_dict_state(state,[1])]
         print(l[0])
         print(l[1])
 
 
     print("Separable qubits,")
-    bell_pair = qk.DictStateFn({'11':1/math.sqrt(2),'00':1/math.sqrt(2)})
+    bell_pair = qkop.DictStateFn({'11': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
     print("of a Bell pair:",StateSeparator.get_separable_qubits(bell_pair))
-    bell_pair_plus = qk.Plus^bell_pair
-    bell_pair_plus = cast(qk.DictStateFn, bell_pair_plus.eval())
+    bell_pair_plus = qkop.Plus ^ bell_pair
+    bell_pair_plus = cast(qkop.DictStateFn, bell_pair_plus.eval())
     print("of a Bell pair tensored with |+>:",StateSeparator.get_separable_qubits(bell_pair_plus))
-    bell_pair_plus_surround = qk.Minus ^ bell_pair ^ qk.Plus
-    bell_pair_plus_surround = cast(qk.DictStateFn, bell_pair_plus_surround.eval())
+    bell_pair_plus_surround = qkop.Minus ^ bell_pair ^ qkop.Plus
+    bell_pair_plus_surround = cast(qkop.DictStateFn, bell_pair_plus_surround.eval())
     print("of |+> otimes Bell pair otimes |->:")
     separated = StateSeparator.get_separable_qubits(bell_pair_plus_surround)
     print("0 :", separated[0])
@@ -39,8 +39,8 @@ if __name__ == "__main__":
     print()
 
     print("More tests:")
-    state = qk.DictStateFn({'10': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
+    state = qkop.DictStateFn({'10': 1 / math.sqrt(2), '00': 1 / math.sqrt(2)})
     print(StateSeparator.get_separable_qubits(state))
 
-    state = qk.DictStateFn({'000':1/math.sqrt(4),'010':1/math.sqrt(4), '100':1/math.sqrt(4),'110':1/math.sqrt(4)})
+    state = qkop.DictStateFn({'000': 1 / math.sqrt(4), '010': 1 / math.sqrt(4), '100': 1 / math.sqrt(4), '110': 1 / math.sqrt(4)})
     print(StateSeparator.get_separable_qubits(state))

--- a/debug/debug_state_separator.py
+++ b/debug/debug_state_separator.py
@@ -9,7 +9,7 @@ from qiskit_opflow_utils import StateSeparator
 import webgui.lattice_view
 from fractions import Fraction
 
-import qiskit.aqua.operators as qk
+import qiskit.opflow as qk
 import qiskit.quantum_info as qkinfo
 
 import math

--- a/debug/util.py
+++ b/debug/util.py
@@ -1,8 +1,8 @@
 from typing import *
-import qiskit.opflow as qk
+import qiskit.opflow as qkop
 
 
-def nice_print_dict_of_dict_states(ds : Dict[int,qk.DictStateFn]) -> str:
+def nice_print_dict_of_dict_states(ds : Dict[int, qkop.DictStateFn]) -> str:
     out = "{"
     for k ,v in ds.items():
         out += "\n\t" + str(k) + " : "

--- a/debug/util.py
+++ b/debug/util.py
@@ -1,5 +1,5 @@
 from typing import *
-import qiskit.aqua.operators as qk
+import qiskit.opflow as qk
 
 
 def nice_print_dict_of_dict_states(ds : Dict[int,qk.DictStateFn]) -> str:

--- a/src/lsqecc/simulation/logical_patch_state_simulation.py
+++ b/src/lsqecc/simulation/logical_patch_state_simulation.py
@@ -21,7 +21,7 @@ import uuid
 from typing import Dict, Iterable, List, Optional, Set, Tuple, TypeVar
 
 import qiskit
-import qiskit.aqua.operators as qk
+import qiskit.opflow as qk
 
 import lsqecc.logical_lattice_ops.logical_lattice_ops as llops
 from lsqecc.pauli_rotations import PauliOperator
@@ -31,12 +31,12 @@ from .qubit_state import DefaultSymbolicStates, SymbolicState
 
 class ConvertersToQiskit:
     @staticmethod
-    def pauli_op(op: PauliOperator) -> Optional[qiskit.aqua.operators.PrimitiveOp]:
-        known_map: Dict[PauliOperator, qiskit.aqua.operators.PrimitiveOp] = {
-            PauliOperator.I: qiskit.aqua.operators.I,
-            PauliOperator.X: qiskit.aqua.operators.X,
-            PauliOperator.Y: qiskit.aqua.operators.Y,
-            PauliOperator.Z: qiskit.aqua.operators.Z,
+    def pauli_op(op: PauliOperator) -> Optional[qiskit.opflow.PrimitiveOp]:
+        known_map: Dict[PauliOperator, qiskit.opflow.PrimitiveOp] = {
+            PauliOperator.I: qiskit.opflow.I,
+            PauliOperator.X: qiskit.opflow.X,
+            PauliOperator.Y: qiskit.opflow.Y,
+            PauliOperator.Z: qiskit.opflow.Z,
         }
         return known_map[op]
 

--- a/src/lsqecc/simulation/qiskit_opflow_utils.py
+++ b/src/lsqecc/simulation/qiskit_opflow_utils.py
@@ -18,7 +18,7 @@
 from typing import Dict, List, Optional
 
 import qiskit.exceptions as qkexcept
-import qiskit.opflow as qk
+import qiskit.opflow as qkop
 import qiskit.quantum_info as qkinfo
 
 
@@ -26,7 +26,7 @@ class StateSeparator:
     """Namespace for functions that deal with separating states."""
 
     @staticmethod
-    def trace_dict_state(state: qk.DictStateFn, trace_over: List[int]) -> qk.DictStateFn:
+    def trace_dict_state(state: qkop.DictStateFn, trace_over: List[int]) -> qkop.DictStateFn:
         """Take a state comprised on n qubits and get the trace of the system over the subsystems
         specified by a list of indices.
 
@@ -34,10 +34,10 @@ class StateSeparator:
         """
         input_statevector = qkinfo.Statevector(state.to_matrix())
         traced_statevector = qkinfo.partial_trace(input_statevector, trace_over).to_statevector()
-        return qk.DictStateFn(traced_statevector.to_dict())
+        return qkop.DictStateFn(traced_statevector.to_dict())
 
     @staticmethod
-    def trace_to_density_op(state: qk.DictStateFn, trace_over: List[int]) -> qkinfo.DensityMatrix:
+    def trace_to_density_op(state: qkop.DictStateFn, trace_over: List[int]) -> qkinfo.DensityMatrix:
         """Take a state comprised on n qubits and get the trace of the system over the subsystems
         specified by a list of indices.
 
@@ -48,7 +48,7 @@ class StateSeparator:
         return qkinfo.partial_trace(input_statevector, trace_over)
 
     @staticmethod
-    def separate(qnum: int, dict_state: qk.DictStateFn) -> Optional[qk.DictStateFn]:
+    def separate(qnum: int, dict_state: qkop.DictStateFn) -> Optional[qkop.DictStateFn]:
         """When a qubit is not entangled (up to a small tolerance) with the rest of the register,
         trace over the rest of the system, giving the qubits' pure state.
 
@@ -67,7 +67,7 @@ class StateSeparator:
             selected_qubit_pure_state = selected_qubit_maybe_mixed_state.to_statevector(
                 rtol=10 ** (-10)
             )
-            return qk.DictStateFn(selected_qubit_pure_state.to_dict())
+            return qkop.DictStateFn(selected_qubit_pure_state.to_dict())
 
         except qkexcept.QiskitError as e:
             if e.message != "Density matrix is not a pure state":
@@ -75,7 +75,7 @@ class StateSeparator:
             return None
 
     @staticmethod
-    def get_separable_qubits(dict_state: qk.DictStateFn) -> Dict[int, qk.DictStateFn]:
+    def get_separable_qubits(dict_state: qkop.DictStateFn) -> Dict[int, qkop.DictStateFn]:
         """For each qubit, numerically detect if it's seprabale or not. If it is, add to
         the result dict, indexed by subsystem, the state traced over the remaining qubits.
 

--- a/src/lsqecc/simulation/qiskit_opflow_utils.py
+++ b/src/lsqecc/simulation/qiskit_opflow_utils.py
@@ -17,8 +17,8 @@
 
 from typing import Dict, List, Optional
 
-import qiskit.aqua.operators as qk
 import qiskit.exceptions as qkexcept
+import qiskit.opflow as qk
 import qiskit.quantum_info as qkinfo
 
 


### PR DESCRIPTION
As outlined in #187 qiskit is deprecating aqua which we use for opflow. Since there are no other occurrences of `aqua` in our project sources, just changing the imports.

Closes #187.