### PR TITLE
Add LazyTensorOp

### DIFF
--- a/src/lsqecc/simulation/lazy_tensor_op.py
+++ b/src/lsqecc/simulation/lazy_tensor_op.py
@@ -39,25 +39,26 @@ class LazyTensorOp(Generic[T]):
     def __init__(self, ops: List[T]):
         self.ops = ops
 
-    def apply_matching_tensors(self, other: "LazyTensorOp[S]", eval=True) -> "LazyTensorOp[R]":
+    def apply_matching_tensors(self, lhs: "LazyTensorOp[S]", eval=True) -> "LazyTensorOp[R]":
+        """Left applies the list of matching tensors to the current object"""
         for i, op in enumerate(self.ops):
-            if op.num_qubits != other.ops[i].num_qubits:
+            if op.num_qubits != lhs.ops[i].num_qubits:
                 raise LazyTensorOpsNotMatchingException(
                     "Items in LazyTensortOp must be matching."
-                    + f"Got:\n {repr(op)}\n and\n {repr(other.ops[i])}"
+                    + f"Got:\n {repr(op)}\n and\n {repr(lhs.ops[i])}"
                 )
 
-        res = [other.ops[i] @ self.ops[i] for i in range(len(self.ops))]
+        res = [lhs.ops[i] @ self.ops[i] for i in range(len(self.ops))]
         if eval:
             res = [op.eval() for op in res]
 
         return LazyTensorOp(res)
 
     def apply_more_granular_lazy_tensor(
-        self, other: "LazyTensorOp[S]", eval=True
+        self, lhs: "LazyTensorOp[S]", eval=True
     ) -> "LazyTensorOp[R]":
-        """Apply an operator expressed as a tensor product such that each applied operators applies
-        exactly to the elements in the tensor product in this object"""
+        """Left pply an operator expressed as a tensor product such that each applied operators
+        applies exactly to the elements in the tensor product in this object"""
         other_op_idx_counter = 0
         other_as_matching_tensor: List[S] = []
 
@@ -66,8 +67,8 @@ class LazyTensorOp(Generic[T]):
             qubits_from_other_for_current_application = 0
             ops_from_other_for_current_application: List[S] = []
             while qubits_from_other_for_current_application < op.num_qubits:
-                ops_from_other_for_current_application.append(other.ops[other_op_idx_counter])
-                qubits_from_other_for_current_application += other.ops[
+                ops_from_other_for_current_application.append(lhs.ops[other_op_idx_counter])
+                qubits_from_other_for_current_application += lhs.ops[
                     other_op_idx_counter
                 ].num_qubits
                 other_op_idx_counter += 1

--- a/src/lsqecc/simulation/lazy_tensor_op.py
+++ b/src/lsqecc/simulation/lazy_tensor_op.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2020-2021 - George Watkins and Alex Nguyen
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+# USA
+
+
+from typing import Generic, List, Tuple, TypeVar
+
+import qiskit.opflow as qkop
+
+from lsqecc.simulation.logical_patch_state_simulation import tensor_list
+
+
+class LazyTensorOpsNotMatchingException(Exception):
+    pass
+
+
+R = TypeVar("R", bound=qkop.OperatorBase)
+S = TypeVar("S", bound=qkop.OperatorBase)
+T = TypeVar("T", bound=qkop.OperatorBase)
+
+
+class LazyTensorOp(Generic[T]):
+    """Store operators such as `I otimes CNOT otimes I otimes I otimes X` as list of the tensor
+    operands. Has methods to apply operators so that the tensor structure is preserved"""
+
+    def __init__(self, ops: List[T]):
+        self.ops = ops
+
+    def apply_matching_tensors(self, other: "LazyTensorOp[S]", eval=True) -> "LazyTensorOp[R]":
+        for i, op in enumerate(self.ops):
+            if op.num_qubits != other.ops[i].num_qubits:
+                raise LazyTensorOpsNotMatchingException(
+                    "Items in LazyTensortOp must be matching."
+                    + f"Got:\n {repr(op)}\n and\n {repr(other.ops[i])}"
+                )
+
+        res = [other.ops[i] @ self.ops[i] for i in range(len(self.ops))]
+        if eval:
+            res = [op.eval() for op in res]
+
+        return LazyTensorOp(res)
+
+    def apply_more_granular_lazy_tensor(
+        self, other: "LazyTensorOp[S]", eval=True
+    ) -> "LazyTensorOp[R]":
+        """Apply an operator expressed as a tensor product such that each applied operators applies
+        exactly to the elements in the tensor product in this object"""
+        other_op_idx_counter = 0
+        other_as_matching_tensor: List[S] = []
+
+        # Group the the more granular tensors so they match the ops in self
+        for op in self.ops:
+            qubits_from_other_for_current_application = 0
+            ops_from_other_for_current_application: List[S] = []
+            while qubits_from_other_for_current_application < op.num_qubits:
+                ops_from_other_for_current_application.append(other.ops[other_op_idx_counter])
+                qubits_from_other_for_current_application += other.ops[
+                    other_op_idx_counter
+                ].num_qubits
+                other_op_idx_counter += 1
+            other_as_matching_tensor.append(tensor_list(ops_from_other_for_current_application))
+
+        return self.apply_matching_tensors(LazyTensorOp(other_as_matching_tensor), eval=eval)
+
+    def get_idxs_of_qubit(self, qubit_idx: int) -> Tuple[int, int]:
+        """Returns index_of_tensor_operand, index_within_tensor_operand"""
+        block_sizes = list(map(lambda op: op.num_qubits, self.ops))
+        sums = [0]
+        for block_size in block_sizes:
+            sums.append(sums[-1] + block_size)
+        print(sums)
+        for i in range(len(sums) - 1):  # skip the last sum because it would be the (n+1)-th block
+            if qubit_idx < sums[i + 1]:
+                return i, qubit_idx - sums[i]
+        raise IndexError(f"Requesting qubit index: {qubit_idx} out of range: {sums[-1]}")
+
+    def disentangle_separable_qubit(self, idx: int):
+        pass  # TODO
+
+    def are_possibly_entangled(self):
+        pass  # TODO
+
+    def get_state(self):
+        pass  # TODO

--- a/tests/simulation/lazy_tensor_op_test.py
+++ b/tests/simulation/lazy_tensor_op_test.py
@@ -32,7 +32,7 @@ from tests.simulation.numpy_matrix_assertions import (
 
 class TestLazyTensorOp:
     @pytest.mark.parametrize(
-        "first, second, expected",
+        "rhs, lhs, expected",
         [
             ([qkop.Zero], [qkop.X], [qkop.One]),
             ([qkop.Plus], [qkop.Z], [qkop.Minus]),
@@ -42,12 +42,12 @@ class TestLazyTensorOp:
     )
     def test_apply_matching_tensors(
         self,
-        first: List[qkop.OperatorBase],
-        second: List[qkop.OperatorBase],
+        rhs: List[qkop.OperatorBase],
+        lhs: List[qkop.OperatorBase],
         expected: List[qkop.OperatorBase],
     ):
-        result: LazyTensorOp[qkop.OperatorBase] = LazyTensorOp(first).apply_matching_tensors(
-            LazyTensorOp(second)
+        result: LazyTensorOp[qkop.OperatorBase] = LazyTensorOp(rhs).apply_matching_tensors(
+            LazyTensorOp(lhs)
         )
         assert len(result.ops) == len(expected)
         for i, op in enumerate(expected):
@@ -59,7 +59,7 @@ class TestLazyTensorOp:
                 assert_eq_numpy_matrices(op.to_matrix(), result.ops[i].to_matrix())
 
     @pytest.mark.parametrize(
-        "first, second",
+        "rhs, lhs",
         [
             ([qkop.I], [qkop.I ^ 2]),
             ([qkop.I ^ 2], [qkop.I]),
@@ -69,14 +69,14 @@ class TestLazyTensorOp:
     )
     def test_apply_matching_tensors_fail(
         self,
-        first: List[qkop.OperatorBase],
-        second: List[qkop.OperatorBase],
+        rhs: List[qkop.OperatorBase],
+        lhs: List[qkop.OperatorBase],
     ):
         with pytest.raises(LazyTensorOpsNotMatchingException):
-            LazyTensorOp(first).apply_matching_tensors(LazyTensorOp(second))
+            LazyTensorOp(rhs).apply_matching_tensors(LazyTensorOp(lhs))
 
     @pytest.mark.parametrize(
-        "first, second, eval, result_type",
+        "rhs, lhs, eval, result_type",
         [
             ([qkop.Zero], [qkop.X], True, qkop.DictStateFn),
             ([qkop.Zero], [qkop.X], False, qkop.ComposedOp),
@@ -84,14 +84,14 @@ class TestLazyTensorOp:
             ([qkop.X], [qkop.X], False, qkop.PauliOp),
         ],
     )
-    def test_apply_matching_tensors_eval(self, first, second, eval, result_type):
+    def test_apply_matching_tensors_eval(self, rhs, lhs, eval, result_type):
         assert isinstance(
-            LazyTensorOp(first).apply_matching_tensors(LazyTensorOp(second), eval=eval).ops[0],
+            LazyTensorOp(rhs).apply_matching_tensors(LazyTensorOp(lhs), eval=eval).ops[0],
             result_type,
         )
 
     @pytest.mark.parametrize(
-        "first, second, expected",
+        "rhs, lhs, expected",
         [
             ([qkop.Zero], [qkop.X], [qkop.One]),
             ([qkop.Plus], [qkop.Z], [qkop.Minus]),
@@ -122,13 +122,13 @@ class TestLazyTensorOp:
     )
     def test_apply_more_granular_tensors(
         self,
-        first: List[qkop.OperatorBase],
-        second: List[qkop.OperatorBase],
+        rhs: List[qkop.OperatorBase],
+        lhs: List[qkop.OperatorBase],
         expected: List[qkop.OperatorBase],
     ):
-        result: LazyTensorOp[qkop.OperatorBase] = LazyTensorOp(
-            first
-        ).apply_more_granular_lazy_tensor(LazyTensorOp(second))
+        result: LazyTensorOp[qkop.OperatorBase] = LazyTensorOp(rhs).apply_more_granular_lazy_tensor(
+            LazyTensorOp(lhs)
+        )
         assert len(result.ops) == len(expected)
         for i, op in enumerate(expected):
             if isinstance(result.ops[i], qkop.DictStateFn) or isinstance(

--- a/tests/simulation/lazy_tensor_op_test.py
+++ b/tests/simulation/lazy_tensor_op_test.py
@@ -1,0 +1,174 @@
+# Copyright (C) 2020-2021 - George Watkins, Alex Nguyen, Varun Seshadri
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+# USA
+from typing import List
+
+import pytest
+import qiskit.opflow as qkop
+
+from lsqecc.simulation.lazy_tensor_op import (
+    LazyTensorOp,
+    LazyTensorOpsNotMatchingException,
+)
+from lsqecc.simulation.qiskit_opflow_utils import to_vector
+from tests.simulation.numpy_matrix_assertions import (
+    assert_eq_numpy_matrices,
+    assert_eq_numpy_vectors,
+)
+
+
+class TestLazyTensorOp:
+    @pytest.mark.parametrize(
+        "first, second, expected",
+        [
+            ([qkop.Zero], [qkop.X], [qkop.One]),
+            ([qkop.Plus], [qkop.Z], [qkop.Minus]),
+            ([qkop.X], [qkop.Z], [1j * qkop.Y]),
+            ([qkop.X, qkop.I ^ qkop.Z], [qkop.I, qkop.Y ^ qkop.I], [qkop.X, qkop.Y ^ qkop.Z]),
+        ],
+    )
+    def test_apply_matching_tensors(
+        self,
+        first: List[qkop.OperatorBase],
+        second: List[qkop.OperatorBase],
+        expected: List[qkop.OperatorBase],
+    ):
+        result: LazyTensorOp[qkop.OperatorBase] = LazyTensorOp(first).apply_matching_tensors(
+            LazyTensorOp(second)
+        )
+        assert len(result.ops) == len(expected)
+        for i, op in enumerate(expected):
+            if isinstance(result.ops[i], qkop.DictStateFn) or isinstance(
+                result.ops[i], qkop.VectorStateFn
+            ):
+                assert_eq_numpy_vectors(to_vector(op), to_vector(result.ops[i]))
+            else:
+                assert_eq_numpy_matrices(op.to_matrix(), result.ops[i].to_matrix())
+
+    @pytest.mark.parametrize(
+        "first, second",
+        [
+            ([qkop.I], [qkop.I ^ 2]),
+            ([qkop.I ^ 2], [qkop.I]),
+            ([qkop.I, qkop.I ^ 2], [qkop.I, qkop.I]),
+            ([qkop.I ^ 2, qkop.I], [qkop.I, qkop.I]),
+        ],
+    )
+    def test_apply_matching_tensors_fail(
+        self,
+        first: List[qkop.OperatorBase],
+        second: List[qkop.OperatorBase],
+    ):
+        with pytest.raises(LazyTensorOpsNotMatchingException):
+            LazyTensorOp(first).apply_matching_tensors(LazyTensorOp(second))
+
+    @pytest.mark.parametrize(
+        "first, second, eval, result_type",
+        [
+            ([qkop.Zero], [qkop.X], True, qkop.DictStateFn),
+            ([qkop.Zero], [qkop.X], False, qkop.ComposedOp),
+            ([qkop.X], [qkop.X], True, qkop.MatrixOp),
+            ([qkop.X], [qkop.X], False, qkop.PauliOp),
+        ],
+    )
+    def test_apply_matching_tensors_eval(self, first, second, eval, result_type):
+        assert isinstance(
+            LazyTensorOp(first).apply_matching_tensors(LazyTensorOp(second), eval=eval).ops[0],
+            result_type,
+        )
+
+    @pytest.mark.parametrize(
+        "first, second, expected",
+        [
+            ([qkop.Zero], [qkop.X], [qkop.One]),
+            ([qkop.Plus], [qkop.Z], [qkop.Minus]),
+            ([qkop.X], [qkop.Z], [1j * qkop.Y]),
+            ([qkop.X ^ qkop.I, qkop.Z], [qkop.X, qkop.Y, qkop.I], [qkop.I ^ qkop.Y, qkop.Z]),
+            ([qkop.X, qkop.I ^ qkop.Z], [qkop.I, qkop.Y, qkop.I], [qkop.X, qkop.Y ^ qkop.Z]),
+            (
+                [qkop.I, qkop.Y ^ qkop.I, qkop.I ^ qkop.X, qkop.H],
+                [qkop.Z, qkop.I ^ qkop.X, qkop.X ^ qkop.Z, qkop.I],
+                [qkop.Z, qkop.Y ^ qkop.X, qkop.X ^ (qkop.Y * 1j), qkop.H],
+            ),
+            (
+                [qkop.I ^ qkop.I ^ qkop.I ^ qkop.I ^ qkop.I],
+                [qkop.I, qkop.I, qkop.X, qkop.I, qkop.I],
+                [qkop.I ^ qkop.I ^ qkop.X ^ qkop.I ^ qkop.I],
+            ),
+            (
+                [qkop.I, qkop.I ^ qkop.I ^ qkop.I ^ qkop.I],
+                [qkop.I, qkop.I, qkop.X, qkop.I, qkop.I],
+                [qkop.I, qkop.I ^ qkop.X ^ qkop.I ^ qkop.I],
+            ),
+            (
+                [qkop.I ^ qkop.I, qkop.I ^ qkop.I ^ qkop.I ^ qkop.I, qkop.I],
+                [qkop.X ^ qkop.H, qkop.I, qkop.Y, qkop.I ^ qkop.I, qkop.Z],
+                [qkop.X ^ qkop.H, qkop.I ^ qkop.Y ^ qkop.I ^ qkop.I, qkop.Z],
+            ),
+        ],
+    )
+    def test_apply_more_granular_tensors(
+        self,
+        first: List[qkop.OperatorBase],
+        second: List[qkop.OperatorBase],
+        expected: List[qkop.OperatorBase],
+    ):
+        result: LazyTensorOp[qkop.OperatorBase] = LazyTensorOp(
+            first
+        ).apply_more_granular_lazy_tensor(LazyTensorOp(second))
+        assert len(result.ops) == len(expected)
+        for i, op in enumerate(expected):
+            if isinstance(result.ops[i], qkop.DictStateFn) or isinstance(
+                result.ops[i], qkop.VectorStateFn
+            ):
+                assert_eq_numpy_vectors(to_vector(op), to_vector(result.ops[i]))
+            else:
+                assert_eq_numpy_matrices(op.to_matrix(), result.ops[i].to_matrix())
+
+    @pytest.mark.parametrize(
+        "operators, "
+        "qubit_idx, "
+        "expected_index_of_tensor_operand, "
+        "expected_index_within_tensor_operand ",
+        [
+            ([qkop.I], 0, 0, 0),
+            ([qkop.I ^ qkop.I], 0, 0, 0),
+            ([qkop.I ^ qkop.I], 1, 0, 1),
+            ([qkop.I, qkop.I], 1, 1, 0),
+            ([qkop.I ^ qkop.I, qkop.I], 1, 0, 1),
+            ([qkop.I ^ qkop.I, qkop.I], 1, 0, 1),
+            ([qkop.I ^ qkop.I ^ qkop.I], 2, 0, 2),
+            ([qkop.I ^ qkop.I, qkop.I], 2, 1, 0),
+            ([qkop.I, qkop.I ^ qkop.I], 2, 1, 1),
+            ([qkop.I, qkop.I, qkop.I], 2, 2, 0),
+            ([qkop.I ^ qkop.I, qkop.I ^ qkop.I], 0, 0, 0),
+            ([qkop.I ^ qkop.I, qkop.I ^ qkop.I], 1, 0, 1),
+            ([qkop.I ^ qkop.I, qkop.I ^ qkop.I], 2, 1, 0),
+            ([qkop.I ^ qkop.I, qkop.I ^ qkop.I], 3, 1, 1),
+        ],
+    )
+    def test_get_idxs_of_qubit(
+        self,
+        operators: List[qkop.OperatorBase],
+        qubit_idx: int,
+        expected_index_of_tensor_operand: int,
+        expected_index_within_tensor_operand: int,
+    ):
+        index_of_tensor_operand, index_within_tensor_operand = LazyTensorOp(
+            operators
+        ).get_idxs_of_qubit(qubit_idx)
+        assert expected_index_of_tensor_operand == index_of_tensor_operand
+        assert expected_index_within_tensor_operand == index_within_tensor_operand


### PR DESCRIPTION
Needed by #138. Allows us to keep track of the global state of the patches on the lattice keeping different state-vectors for parts that are not entangled, like ancilla patches waiting to be used or that are already measured.

Has an API to apply operators to this state without worrying about in which state vector the patch is.

First round of functionality and tests. Later will add ways to entangle patches in and use it `logical_patch_state_simulation` 