### PR TITLE
Lazy Tensor Simulation

### DIFF
--- a/src/lsqecc/logical_lattice_ops/logical_lattice_ops.py
+++ b/src/lsqecc/logical_lattice_ops/logical_lattice_ops.py
@@ -276,6 +276,12 @@ class PiOverFourCorrectionCondition(coc.EvaluationCondition):
         if not self.multi_body_measurement.does_evaluate():
             return False
 
+        if (
+            self.multi_body_measurement.get_outcome() is None
+            or self.ancilla_measurement.get_outcome() is None
+        ):
+            return True  # Always evaluate an op when no simulation is present
+
         out = (
             self.multi_body_measurement.get_outcome() * self.ancilla_measurement.get_outcome() == -1
         )
@@ -293,6 +299,9 @@ class PiOverEightCorrectionConditionPiOverFour(coc.EvaluationCondition):
         if not self.multi_body_measurement.does_evaluate():
             return False
 
+        if self.multi_body_measurement.get_outcome() is None:
+            return True  # Always evaluate an op when no simulation is present
+
         out = self.multi_body_measurement.get_outcome() == -1
         if self.invert:
             out = not out
@@ -306,5 +315,8 @@ class PiOverEightCorrectionConditionPiOverTwo(coc.EvaluationCondition):
     def does_evaluate(self):
         if not self.ancilla_measurement.does_evaluate():
             return False
+
+        if self.ancilla_measurement.get_outcome() is None:
+            return True  # Always evaluate an op when no simulation is present
 
         return self.ancilla_measurement.get_outcome() == -1

--- a/src/lsqecc/pauli_rotations/circuit.py
+++ b/src/lsqecc/pauli_rotations/circuit.py
@@ -322,6 +322,14 @@ class PauliOpCircuit(object):
         return ret_circ
 
     @staticmethod
+    def from_list(pauli_op_list: List[PauliProductOperation]):
+        c = PauliOpCircuit(pauli_op_list[0].qubit_num)
+        for op in pauli_op_list:
+            assert c.qubit_num == op.qubit_num
+            c.add_pauli_block(op)
+        return c
+
+    @staticmethod
     def load_reversible_from_qasm_string(quasm_string: str) -> "PauliOpCircuit":
         """Load a string as if it were a QASM circuit. Only supports reversible circuits."""
 

--- a/src/lsqecc/pipeline/json_pipeline.py
+++ b/src/lsqecc/pipeline/json_pipeline.py
@@ -44,7 +44,6 @@ class _SliceArrayJSONEncoder(json.JSONEncoder):
         elif isinstance(obj, vac.VisualArrayCell):
             obj_with_good_keys = obj.__dict__
             obj_with_good_keys["edges"] = dict([(k.value, v) for k, v in obj.edges.items()])
-            print(obj_with_good_keys)
             return obj_with_good_keys
         elif isinstance(obj, object):
             return obj.__dict__

--- a/src/lsqecc/pipeline/lattice_surgery_compilation_pipeline.py
+++ b/src/lsqecc/pipeline/lattice_surgery_compilation_pipeline.py
@@ -24,6 +24,7 @@ import lsqecc.lattice_array.visual_array_cell as vac
 import lsqecc.logical_lattice_ops.logical_lattice_ops as llops
 import lsqecc.patches.lattice_surgery_computation_composer as lscc
 import lsqecc.pauli_rotations.segmented_qasm_parser as segmented_qasm_parser
+import lsqecc.simulation.logical_patch_state_simulation as lssim
 from lsqecc.lattice_array import sparse_lattice_to_array
 
 GUISlice = List[List[Optional[vac.VisualArrayCell]]]  # 2D array of cells
@@ -32,15 +33,21 @@ __all__ = ["compile_file", "GUISlice"]
 
 
 def compile_file(
-    circuit_file_name: str, apply_litinski_transform: bool = True
+    circuit_file_name: str,
+    apply_litinski_transform: bool = True,
+    simulation_type: lssim.SimulatorType = lssim.SimulatorType.FULL_STATE_VECTOR,
 ) -> Tuple[List[GUISlice], str]:
     """DEPRECATED. compile_str"""
     with open(circuit_file_name) as input_file:
-        return compile_str(input_file.read(), apply_litinski_transform)
+        return compile_str(
+            input_file.read(), apply_litinski_transform, simulation_type=simulation_type
+        )
 
 
 def compile_str(
-    qasm_circuit: str, apply_litinski_transform: bool = True
+    qasm_circuit: str,
+    apply_litinski_transform: bool = True,
+    simulation_type: lssim.SimulatorType = lssim.SimulatorType.FULL_STATE_VECTOR,
 ) -> Tuple[List[GUISlice], str]:
     """Returns gui slices and the text of the circuit as processed in various stages"""
     composer_class = lscc.LatticeSurgeryComputation
@@ -59,6 +66,7 @@ def compile_str(
 
     # TODO add user flag
     input_circuit = input_circuit.get_y_free_equivalent()
+
     if apply_litinski_transform:
         input_circuit.apply_transformation()
         input_circuit = input_circuit.get_y_free_equivalent()
@@ -66,8 +74,8 @@ def compile_str(
         compilation_text += input_circuit.render_ascii()
 
     logical_computation = llops.LogicalLatticeComputation(input_circuit)
-    lsc = composer_class.make_computation_with_simulation(
-        logical_computation, layout_types.SimplePreDistilledStates
+    lsc = composer_class.make_computation(
+        logical_computation, layout_types.SimplePreDistilledStates, simulation_type=simulation_type
     )
 
     return list(map(sparse_lattice_to_array, lsc.composer.getSlices())), compilation_text

--- a/src/lsqecc/pipeline/lattice_surgery_compilation_pipeline.py
+++ b/src/lsqecc/pipeline/lattice_surgery_compilation_pipeline.py
@@ -59,7 +59,6 @@ def compile_str(
 
     # TODO add user flag
     input_circuit = input_circuit.get_y_free_equivalent()
-
     if apply_litinski_transform:
         input_circuit.apply_transformation()
         input_circuit = input_circuit.get_y_free_equivalent()

--- a/src/lsqecc/simulation/lazy_tensor_op.py
+++ b/src/lsqecc/simulation/lazy_tensor_op.py
@@ -96,6 +96,9 @@ class LazyTensorOp(Generic[T]):
         self.ops[operand_idx1] = tmp
 
     def merge_operand_with_the_next(self, target_operand_idx: int) -> None:
+        if target_operand_idx >= len(self.ops) - 1:
+            raise IndexError()
+
         new_ops = [op for i, op in enumerate(self.ops) if i != target_operand_idx + 1]
         new_ops[target_operand_idx] = (
             self.ops[target_operand_idx] ^ self.ops[target_operand_idx + 1]
@@ -156,6 +159,9 @@ class LazyTensorOp(Generic[T]):
                 for op1, op2 in zip(self.ops, other.ops)
             ]
         )
+
+    def get_num_qubits(self):
+        return sum(map(lambda x: x.num_qubits, self.ops))
 
     def __repr__(self):
         return f"<LazyTensorOps ops.len={len(self.ops)} ops={self.ops}>"

--- a/src/lsqecc/simulation/lazy_tensor_op.py
+++ b/src/lsqecc/simulation/lazy_tensor_op.py
@@ -39,7 +39,7 @@ class LazyTensorOp(Generic[T]):
     operands. Has methods to apply operators so that the tensor structure is preserved."""
 
     def __init__(self, ops: List[T]):
-        self.ops = ops  # TODO rename to operands
+        self.ops = [op for op in ops]  # TODO rename to operands
 
     def apply_matching_tensors(self, lhs: "LazyTensorOp[S]", eval=True) -> "LazyTensorOp[R]":
         """Left applies the list of matching tensors to the current object"""

--- a/src/lsqecc/simulation/lazy_tensor_op.py
+++ b/src/lsqecc/simulation/lazy_tensor_op.py
@@ -20,7 +20,6 @@ from typing import Generic, List, Tuple, TypeVar
 
 import qiskit.opflow as qkop
 
-from lsqecc.simulation.logical_patch_state_simulation import tensor_list
 from lsqecc.simulation.qiskit_opflow_utils import StateSeparator
 
 
@@ -115,3 +114,10 @@ class LazyTensorOp(Generic[T]):
 
     def get_state(self):
         pass  # TODO
+
+
+def tensor_list(input_list):
+    t = input_list[0]
+    for s in input_list[1:]:
+        t = t ^ s
+    return t

--- a/src/lsqecc/simulation/lazy_tensor_op.py
+++ b/src/lsqecc/simulation/lazy_tensor_op.py
@@ -39,7 +39,7 @@ class LazyTensorOp(Generic[T]):
     operands. Has methods to apply operators so that the tensor structure is preserved."""
 
     def __init__(self, ops: List[T]):
-        self.ops = [op for op in ops]  # TODO rename to operands
+        self.ops = ops[:]  # TODO rename to operands
 
     def apply_matching_tensors(self, lhs: "LazyTensorOp[S]", eval=True) -> "LazyTensorOp[R]":
         """Left applies the list of matching tensors to the current object"""
@@ -105,9 +105,10 @@ class LazyTensorOp(Generic[T]):
         return self.get_idx_of_first_qubit_for_each_operand()[operand_idx]
 
     def swap_operands(self, operand_idx1: int, operand_idx2: int) -> None:
-        tmp = self.ops[operand_idx2]
-        self.ops[operand_idx2] = self.ops[operand_idx1]
-        self.ops[operand_idx1] = tmp
+        self.ops[operand_idx2], self.ops[operand_idx1] = (
+            self.ops[operand_idx1],
+            self.ops[operand_idx2],
+        )
 
     def merge_operand_with_the_next(self, target_operand_idx: int) -> None:
         if target_operand_idx >= len(self.ops) - 1:

--- a/src/lsqecc/simulation/logical_patch_state_simulation.py
+++ b/src/lsqecc/simulation/logical_patch_state_simulation.py
@@ -349,12 +349,12 @@ class LazyTensorPatchSimulator(PatchSimulator):
             operand = self.logical_state.ops[operand_idx]
 
             local_observable = ConvertersToQiskit.pauli_op(logical_op.op)
-            observable_global_to_operand = circuit_apply_op_to_qubit(
+            operand_wide_observable = circuit_apply_op_to_qubit(
                 qkop.I ^ operand.num_qubits, local_observable, idx_within_operand
             )
 
             distribution = ProjectiveMeasurement.pauli_product_measurement_distribution(
-                observable_global_to_operand, operand
+                operand_wide_observable, operand
             )
             outcome: ProjectiveMeasurement.BinaryMeasurementOutcome = proportional_choice(
                 distribution
@@ -383,19 +383,19 @@ class LazyTensorPatchSimulator(PatchSimulator):
             size_of_first_operand = self.logical_state.ops[0].num_qubits
 
             # Make a global observable for the operator
-            global_observable = qkop.I ^ size_of_first_operand
+            operand_wide_observable = qkop.I ^ size_of_first_operand
             for patch_uuid in logical_op.get_operating_patches():
                 qubit_idx = self.mapper.get_idx(patch_uuid)
                 assert qubit_idx < size_of_first_operand
-                global_observable = circuit_apply_op_to_qubit(
-                    global_observable,
+                operand_wide_observable = circuit_apply_op_to_qubit(
+                    operand_wide_observable,
                     ConvertersToQiskit.pauli_op(logical_op.patch_pauli_operator_map[patch_uuid]),
                     qubit_idx,
                 )
 
             distribution = list(
                 ProjectiveMeasurement.pauli_product_measurement_distribution(
-                    global_observable, self.logical_state.ops[0]
+                    operand_wide_observable, self.logical_state.ops[0]
                 )
             )
             outcome = proportional_choice(distribution)

--- a/src/lsqecc/simulation/logical_patch_state_simulation.py
+++ b/src/lsqecc/simulation/logical_patch_state_simulation.py
@@ -46,7 +46,7 @@ class ConvertersToQiskit:
         return zero_ampl * qkop.Zero + one_ampl * qkop.One
 
 
-def circuit_add_op_to_qubit(
+def circuit_apply_op_to_qubit(
     circ: qkop.OperatorBase, op: qkop.OperatorBase, idx: int
 ) -> qkop.CircuitOp:
     """Take a local operator (applied to a single qubit) and apply it to the given circuit."""
@@ -232,10 +232,8 @@ class PatchSimulator:
             operand = self.logical_state.ops[operand_idx]
 
             local_observable = ConvertersToQiskit.pauli_op(logical_op.op)
-            observable_global_to_operand = (
-                (qkop.I ^ idx_within_operand)
-                ^ local_observable
-                ^ (qkop.I ^ (operand.num_qubits - idx_within_operand - 1))
+            observable_global_to_operand = circuit_apply_op_to_qubit(
+                qkop.I ^ operand.num_qubits, local_observable, idx_within_operand
             )
 
             distribution = ProjectiveMeasurement.pauli_product_measurement_distribution(
@@ -255,7 +253,7 @@ class PatchSimulator:
             operand_idx, idx_within_operand = self.logical_state.get_idxs_of_qubit(op_idx)
             operand = self.logical_state.ops[operand_idx]
 
-            symbolic_state = circuit_add_op_to_qubit(
+            symbolic_state = circuit_apply_op_to_qubit(
                 operand,
                 ConvertersToQiskit.pauli_op(logical_op.pauli_matrix),
                 idx_within_operand,

--- a/src/lsqecc/simulation/logical_patch_state_simulation.py
+++ b/src/lsqecc/simulation/logical_patch_state_simulation.py
@@ -191,6 +191,10 @@ def tensor_list(input_list):
 
 class PatchSimulator:
     def __init__(self, logical_computation: llops.LogicalLatticeComputation):
+        # TODO decouple the simulation frm the logical computation. It should be possible to do it
+        # because the logical computation is only used to construct the mapper and the initial
+        # states.
+
         self.logical_computation = logical_computation
         self.mapper = PatchToQubitMapper(logical_computation)
         self.logical_state: LazyTensorOp[qkop.StateFn] = self._make_initial_logical_state()

--- a/src/lsqecc/simulation/logical_patch_state_simulation.py
+++ b/src/lsqecc/simulation/logical_patch_state_simulation.py
@@ -415,6 +415,7 @@ class LazyTensorPatchSimulator(PatchSimulator):
         involved_operand_idxs: List[int] = [
             self.logical_state.get_idxs_of_qubit(qubit_idx)[0] for qubit_idx in involved_qubit_idxs
         ]
+        involved_operand_idxs = list(set(involved_operand_idxs))  # Remove duplicates
         involved_operand_idxs.sort()
 
         operand_swap_target_counter = 0

--- a/src/lsqecc/simulation/logical_patch_state_simulation.py
+++ b/src/lsqecc/simulation/logical_patch_state_simulation.py
@@ -340,7 +340,7 @@ class LazyTensorPatchSimulator(PatchSimulator):
 
         if not logical_op.does_evaluate():
             raise Exception(
-                "apply_logical_operation called with non evaluating operation :" + repr(logical_op)
+                f"apply_logical_operation called with non evaluating operation: {repr(logical_op)}"
             )
 
         if isinstance(logical_op, llops.SinglePatchMeasurement):
@@ -412,14 +412,9 @@ class LazyTensorPatchSimulator(PatchSimulator):
             for patch_uuid in logical_op.get_operating_patches()
         ]
 
-        involved_operand_idxs: List[int] = list(
-            set(
-                [
-                    self.logical_state.get_idxs_of_qubit(qubit_idx)[0]
-                    for qubit_idx in involved_qubit_idxs
-                ]
-            )
-        )
+        involved_operand_idxs: List[int] = [
+            self.logical_state.get_idxs_of_qubit(qubit_idx)[0] for qubit_idx in involved_qubit_idxs
+        ]
         involved_operand_idxs.sort()
 
         operand_swap_target_counter = 0

--- a/src/lsqecc/simulation/logical_patch_state_simulation.py
+++ b/src/lsqecc/simulation/logical_patch_state_simulation.py
@@ -249,7 +249,7 @@ class PatchSimulator:
 
             if idx_within_operand == operand.num_qubits - 1:
                 self.logical_state.separate_last_qubit_of_operand(operand_idx)
-
+                # TODO use .permute + reindexing to detach any qubit, not just the last
         elif isinstance(logical_op, llops.LogicalPauli):
             op_idx = self.mapper.get_idx(logical_op.qubit_uuid)
             operand_idx, idx_within_operand = self.logical_state.get_idxs_of_qubit(op_idx)

--- a/src/lsqecc/simulation/logical_patch_state_simulation.py
+++ b/src/lsqecc/simulation/logical_patch_state_simulation.py
@@ -24,7 +24,7 @@ import qiskit.opflow as qkop
 
 import lsqecc.logical_lattice_ops.logical_lattice_ops as llops
 from lsqecc.pauli_rotations import PauliOperator
-from lsqecc.simulation.lazy_tensor_op import LazyTensorOp
+from lsqecc.simulation.lazy_tensor_op import LazyTensorOp, tensor_list
 
 from .qubit_state import DefaultSymbolicStates, SymbolicState
 
@@ -180,13 +180,6 @@ class PatchToQubitMapper:
                     patch_list.append(new_patch)
 
         return patch_list
-
-
-def tensor_list(input_list):
-    t = input_list[0]
-    for s in input_list[1:]:
-        t = t ^ s
-    return t
 
 
 class PatchSimulator:

--- a/src/lsqecc/simulation/qiskit_opflow_utils.py
+++ b/src/lsqecc/simulation/qiskit_opflow_utils.py
@@ -14,12 +14,12 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 # USA
-
+import math
 from typing import Dict, List, Optional, cast
 
 import qiskit.exceptions as qkexcept
-import qiskit.opflow as qkop
 import qiskit.quantum_info as qkinfo
+from qiskit import opflow as qkop
 
 
 class TraceOverEntireStateException(Exception):
@@ -119,3 +119,6 @@ def to_vector(state: qkop.OperatorBase):
     if len(state.to_matrix().shape) == 2:
         return state.to_matrix()[0]
     return state.to_matrix()
+
+
+bell_pair = qkop.DictStateFn({"11": 1 / math.sqrt(2), "00": 1 / math.sqrt(2)})

--- a/src/lsqecc/simulation/qiskit_opflow_utils.py
+++ b/src/lsqecc/simulation/qiskit_opflow_utils.py
@@ -32,6 +32,9 @@ class StateSeparator:
 
         Assumes state is separable as a DictStateFn can only represent pure states.
         """
+        if not trace_over:
+            return state.copy()
+
         input_statevector = qkinfo.Statevector(state.to_matrix())
         traced_statevector = qkinfo.partial_trace(input_statevector, trace_over).to_statevector()
         return qkop.DictStateFn(traced_statevector.to_dict())
@@ -54,6 +57,8 @@ class StateSeparator:
 
         If the selected qubit is entangled return None.
         """
+        if dict_state.num_qubits == 1 and qnum == 0:
+            return dict_state.copy()
 
         remaing_qubits = list(range(dict_state.num_qubits))
         remaing_qubits.remove(qnum)

--- a/src/lsqecc/simulation/qiskit_opflow_utils.py
+++ b/src/lsqecc/simulation/qiskit_opflow_utils.py
@@ -22,6 +22,13 @@ import qiskit.opflow as qkop
 import qiskit.quantum_info as qkinfo
 
 
+class TraceOverEntireStateException(Exception):
+    def __init__(self):
+        super().__init__(
+            "Won't trace over the entire state, because it can't output a StateFn object"
+        )
+
+
 class StateSeparator:
     """Namespace for functions that deal with separating states."""
 
@@ -34,6 +41,9 @@ class StateSeparator:
         """
         if not trace_over:
             return state.copy()
+
+        if set(trace_over) == set(range(state.num_qubits)):
+            raise TraceOverEntireStateException()
 
         input_statevector = qkinfo.Statevector(state.to_matrix())
         traced_statevector = qkinfo.partial_trace(input_statevector, trace_over).to_statevector()

--- a/src/lsqecc/simulation/qubit_state.py
+++ b/src/lsqecc/simulation/qubit_state.py
@@ -19,7 +19,11 @@ from __future__ import annotations
 
 import cmath
 import enum
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import qiskit.opflow as qkop
+
+import lsqecc.simulation.qiskit_opflow_utils as qkutil
 
 if TYPE_CHECKING:
     from lsqecc.pauli_rotations import PauliOperator
@@ -157,3 +161,16 @@ class DefaultSymbolicStates:
         elif s == DefaultSymbolicStates.Magic:
             return cmath.sqrt(2) / 2, cmath.exp(1j * cmath.pi / 4) / cmath.sqrt(2)
         raise NotImplementedError
+
+    @staticmethod
+    def from_state_fn(state: qkop.StateFn) -> SymbolicState:
+        alpha, beta = qkutil.to_vector(state)
+        return DefaultSymbolicStates.from_amplitudes(alpha, beta)
+
+    @staticmethod
+    def from_maybe_state_fn(state: Optional[qkop.StateFn]) -> SymbolicState:
+        return (
+            DefaultSymbolicStates.from_state_fn(state)
+            if state is not None
+            else DefaultSymbolicStates.UnknownState
+        )

--- a/tests/pauli_rotations/circuit_test.py
+++ b/tests/pauli_rotations/circuit_test.py
@@ -111,6 +111,17 @@ def test_add_single_operator():
     assert circuit.ops[1] == PauliRotation.from_list([I, Y, I, I], Fraction(1, 4))
 
 
+def test_from_list():
+    c = PauliOpCircuit.from_list(
+        [PauliRotation.from_list([X, I, Y, Z], Fraction(1, 4)), Measurement.from_list([Z, Y, X, I])]
+    )
+    assert isinstance(c.ops[0], PauliRotation)
+    assert c.ops[0] == PauliRotation.from_list([X, I, Y, Z], Fraction(1, 4))
+    assert isinstance(c.ops[1], Measurement)
+    assert c.ops[1] == Measurement.from_list([Z, Y, X, I])
+    assert len(c.ops) == 2
+
+
 @pytest.mark.parametrize(
     "rotation1, rotation2",
     [

--- a/tests/simulation/lazy_tensor_op_test.py
+++ b/tests/simulation/lazy_tensor_op_test.py
@@ -196,6 +196,9 @@ class TestLazyTensorOp:
         [
             ([qkop.I, qkop.X], 0, [qkop.I ^ qkop.X]),
             ([qkop.I ^ qkop.X, qkop.Y, qkop.Z], 0, [qkop.I ^ qkop.X ^ qkop.Y, qkop.Z]),
+            ([qkop.I ^ qkop.X, qkop.Y, qkop.Z], 1, [qkop.I ^ qkop.X, qkop.Y ^ qkop.Z]),
+            ([qkop.I, qkop.X, qkop.Y, qkop.Z], 0, [qkop.I ^ qkop.X, qkop.Y, qkop.Z]),
+            ([qkop.I, qkop.X, qkop.Y, qkop.Z], 1, [qkop.I, qkop.X ^ qkop.Y, qkop.Z]),
             ([qkop.I, qkop.X, qkop.Y, qkop.Z], 2, [qkop.I, qkop.X, qkop.Y ^ qkop.Z]),
         ],
     )
@@ -210,8 +213,28 @@ class TestLazyTensorOp:
         assert expected_list == state.ops
 
     @pytest.mark.parametrize(
+        "list, operand_idx",
+        [
+            ([qkop.I, qkop.X], 1),
+            ([qkop.I, qkop.X], 2),
+            ([qkop.I ^ qkop.X, qkop.Y, qkop.Z], 2),
+            ([qkop.I ^ qkop.X, qkop.Y, qkop.Z], 3),
+            ([qkop.I ^ qkop.X, qkop.Y, qkop.Z], 100),
+        ],
+    )
+    def test_merge_operand_with_the_next_fail(
+        self,
+        list: List[qkop.OperatorBase],
+        operand_idx: int,
+    ):
+        state = LazyTensorOp(list)
+        with pytest.raises(IndexError):
+            state.merge_operand_with_the_next(operand_idx)
+
+    @pytest.mark.parametrize(
         "list, n, expected_list",
         [
+            ([qkop.I], 0, [qkop.I]),
             ([qkop.I, qkop.X], 0, [qkop.I, qkop.X]),
             ([qkop.I, qkop.X], 1, [qkop.I ^ qkop.X]),
             ([qkop.I, qkop.X, qkop.Y, qkop.Z], 0, [qkop.I, qkop.X, qkop.Y, qkop.Z]),

--- a/tests/simulation/lazy_tensor_op_test.py
+++ b/tests/simulation/lazy_tensor_op_test.py
@@ -171,3 +171,40 @@ class TestLazyTensorOp:
         ).get_idxs_of_qubit(qubit_idx)
         assert expected_index_of_tensor_operand == index_of_tensor_operand
         assert expected_index_within_tensor_operand == index_within_tensor_operand
+
+    @pytest.mark.parametrize(
+        "lhs, rhs, should_match",
+        [
+            ([qkop.Zero], [qkop.Zero], True),
+            ([qkop.Zero], [qkop.One], True),
+            ([qkop.Zero], [qkop.Zero ^ qkop.Zero], False),
+            ([qkop.Zero, qkop.Zero], [qkop.Zero, qkop.Zero], True),
+            ([qkop.Zero, qkop.Zero], [qkop.One, qkop.One], True),
+            ([qkop.Zero, qkop.Zero], [qkop.Zero ^ qkop.Zero], False),
+            ([qkop.Zero ^ qkop.Plus, qkop.Zero], [qkop.Zero ^ qkop.Zero, qkop.Minus], True),
+            ([qkop.Zero, qkop.Zero ^ qkop.Plus], [qkop.Zero ^ qkop.Plus, qkop.Minus], False),
+        ],
+    )
+    def test_matches(
+        self, lhs: List[qkop.OperatorBase], rhs: List[qkop.OperatorBase], should_match: bool
+    ):
+        assert LazyTensorOp(lhs).matches(LazyTensorOp(rhs)) == should_match
+
+    @pytest.mark.parametrize(
+        "lhs, rhs, should_match",
+        [
+            ([qkop.Zero], [qkop.Zero], True),
+            ([qkop.Zero], [qkop.One], False),
+            ([qkop.Zero], [qkop.Zero ^ qkop.Zero], False),
+            ([qkop.Zero, qkop.Zero], [qkop.Zero, qkop.Zero], True),
+            ([qkop.Zero, qkop.Zero], [qkop.One, qkop.Zero], False),
+            ([qkop.Zero, qkop.Zero], [qkop.Zero ^ qkop.Zero], False),
+            ([qkop.Zero ^ qkop.Minus, qkop.Zero], [qkop.Zero ^ qkop.Minus, qkop.Zero], True),
+            ([qkop.Zero ^ qkop.Minus, qkop.Zero], [qkop.Zero ^ qkop.Zero, qkop.Zero], False),
+            ([qkop.Zero ^ qkop.Plus, qkop.Zero], [qkop.Zero ^ qkop.Zero, qkop.Minus], False),
+        ],
+    )
+    def test_matching_approx_eq_vector(
+        self, lhs: List[qkop.OperatorBase], rhs: List[qkop.OperatorBase], should_match: bool
+    ):
+        assert LazyTensorOp(lhs).matches(LazyTensorOp(rhs)) == should_match

--- a/tests/simulation/logical_patch_state_simulation_test.py
+++ b/tests/simulation/logical_patch_state_simulation_test.py
@@ -30,7 +30,7 @@ from lsqecc.simulation.logical_patch_state_simulation import (
     PatchSimulator,
     PatchToQubitMapper,
     ProjectiveMeasurement,
-    circuit_add_op_to_qubit,
+    circuit_apply_op_to_qubit,
     proportional_choice,
 )
 from lsqecc.simulation.qiskit_opflow_utils import bell_pair, to_vector
@@ -53,10 +53,10 @@ class Outcome(ProjectiveMeasurement.BinaryMeasurementOutcome):
         (qkop.Zero ^ qkop.Zero ^ qkop.Zero, qkop.X, 2, qkop.One ^ qkop.Zero ^ qkop.Zero),
     ],
 )
-def test_circuit_add_op_to_qubit(
+def test_circuit_apply_op_to_qubit(
     circuit: qkop.OperatorBase, op, idx, desired_state: qkop.OperatorBase
 ):
-    circuit_with_op_applied = circuit_add_op_to_qubit(circuit, op, idx)
+    circuit_with_op_applied = circuit_apply_op_to_qubit(circuit, op, idx)
     assert_eq_numpy_vectors(
         to_vector(circuit_with_op_applied.eval()), to_vector(desired_state.eval())
     )
@@ -337,7 +337,7 @@ class TestPatchSimulator:
             (
                 [qkop.Zero ^ qkop.Zero],
                 rotation.PauliRotation.from_list([I, X], Fraction(1, 2)),
-                [[qkop.Zero ^ qkop.One]],
+                [[qkop.One ^ qkop.Zero]],  # qubit index is in reverse of the ^ operator
             ),
         ],
     )

--- a/tests/simulation/numpy_matrix_assertions.py
+++ b/tests/simulation/numpy_matrix_assertions.py
@@ -17,6 +17,9 @@
 
 import numpy as np
 import pytest
+import qiskit.opflow as qkop
+
+from lsqecc.simulation.qiskit_opflow_utils import to_vector
 
 
 def assert_eq_numpy_vectors(lhs: np.array, rhs: np.array):
@@ -34,3 +37,7 @@ def assert_eq_numpy_matrices(lhs: np.array, rhs: np.array):
     for row in range(rows):
         for col in range(cols):
             assert lhs[row, col] == pytest.approx(rhs[row, col])
+
+
+def assert_eq_numpy_vectorable(lhs: qkop.OperatorBase, rhs: qkop.OperatorBase):
+    return assert_eq_numpy_vectors(to_vector(lhs), to_vector(rhs))

--- a/tests/simulation/qiskit_opflow_utils_test.py
+++ b/tests/simulation/qiskit_opflow_utils_test.py
@@ -41,6 +41,8 @@ class TestStateSeparator:
     @pytest.mark.parametrize(
         "state, trace_over, desired_state",
         [
+            (qkop.Zero, [], qkop.Zero),
+            (qkop.Zero ^ qkop.One, [], qkop.Zero ^ qkop.One),
             (qkop.Zero ^ qkop.One, [0], qkop.Zero),
             (qkop.Zero ^ qkop.One, [1], qkop.One),
             (qkop.Zero ^ qkop.Plus, [0], qkop.Zero),
@@ -98,6 +100,8 @@ class TestStateSeparator:
     @pytest.mark.parametrize(
         "qnum, state, desired_state",
         [
+            (0, qkop.One, qkop.One),
+            (0, qkop.Zero, qkop.Zero),
             (0, qkop.Plus ^ qkop.One, qkop.One),
             (1, qkop.Plus ^ qkop.One, qkop.Plus),
             (1, qkop.Plus ^ qkop.Zero ^ qkop.One, qkop.Zero),

--- a/tests/simulation/qiskit_opflow_utils_test.py
+++ b/tests/simulation/qiskit_opflow_utils_test.py
@@ -26,13 +26,12 @@ from qiskit import QiskitError
 from lsqecc.simulation.qiskit_opflow_utils import (
     StateSeparator,
     TraceOverEntireStateException,
+    bell_pair,
     to_dict_fn,
     to_vector,
 )
 
 from .numpy_matrix_assertions import assert_eq_numpy_matrices, assert_eq_numpy_vectors
-
-bell_pair = qkop.DictStateFn({"11": 1 / math.sqrt(2), "00": 1 / math.sqrt(2)})
 
 
 # The tracing functionality is delegated to qiskit we mostly check that our interface is working

--- a/tests/simulation/qiskit_opflow_utils_test.py
+++ b/tests/simulation/qiskit_opflow_utils_test.py
@@ -15,7 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 # USA
 import math
-from typing import Dict, cast
+from typing import Dict, List, cast
 
 import numpy as np
 import pytest
@@ -23,7 +23,12 @@ import qiskit.opflow as qkop
 import qiskit.quantum_info as qkinfo
 from qiskit import QiskitError
 
-from lsqecc.simulation.qiskit_opflow_utils import StateSeparator, to_dict_fn, to_vector
+from lsqecc.simulation.qiskit_opflow_utils import (
+    StateSeparator,
+    TraceOverEntireStateException,
+    to_dict_fn,
+    to_vector,
+)
 
 from .numpy_matrix_assertions import assert_eq_numpy_matrices, assert_eq_numpy_vectors
 
@@ -66,6 +71,19 @@ class TestStateSeparator:
     def test_trace_dict_state_fail(self):
         with pytest.raises(QiskitError):
             StateSeparator.trace_dict_state(bell_pair, [1])
+
+    @pytest.mark.parametrize(
+        "state, trace_over",
+        [
+            (qkop.Zero, [0]),
+            (qkop.Zero ^ qkop.One, [0, 1]),
+        ],
+    )
+    def test_trace_over_dict_state_all_qubits(
+        self, state: qkop.OperatorBase, trace_over: List[int]
+    ):
+        with pytest.raises(TraceOverEntireStateException):
+            StateSeparator.trace_dict_state(cast(qkop.DictStateFn, state.eval()), trace_over)
 
     @pytest.mark.parametrize(
         "state, trace_over, desired_state",


### PR DESCRIPTION
If we have a state like:

`|0> otime |1> otimes (|00>+|11>)/sqrt(2) otimes |0>`

We don't need to expanded out to a state vector with 32 entries to apply, say an X gate to the second qubit.

This PR introduces simulation that reduces the size of the state vectors involved in simulation by tracking the list of tensors operands that make up the tensor state. The class used to hold these tensored operands states is `LazyTensorOps` introduced in #213.

Operations supported:
 - [x] Single qubit gates
 - [x] Single qubit measurements
 - [x] Multibody measurements

Closes #138 