### PR TITLE
fix to include isNegative attribute of measurements to llops

### DIFF
--- a/src/lsqecc/logical_lattice_ops/logical_lattice_ops.py
+++ b/src/lsqecc/logical_lattice_ops/logical_lattice_ops.py
@@ -41,17 +41,23 @@ class LogicalLatticeOperation(coc.ConditionalOperation):
 
 
 class SinglePatchMeasurement(LogicalLatticeOperation, coc.HasPauliEigenvalueOutcome):
-    def __init__(self, qubit_uuid: uuid.UUID, op: PauliOperator):
+    def __init__(
+        self, qubit_uuid: uuid.UUID, op: PauliOperator, isNegative: Optional[bool] = False
+    ):
         self.qubit_uuid = qubit_uuid
         self.op = op
+        self.isNegative = isNegative
 
     def get_operating_patches(self) -> List[uuid.UUID]:
         return [self.qubit_uuid]
 
 
 class MultiBodyMeasurement(LogicalLatticeOperation, coc.HasPauliEigenvalueOutcome):
-    def __init__(self, patch_pauli_operator_map: Dict[uuid.UUID, PauliOperator]):
+    def __init__(
+        self, patch_pauli_operator_map: Dict[uuid.UUID, PauliOperator], isNegative: bool = False
+    ):
         self.patch_pauli_operator_map = patch_pauli_operator_map
+        self.isNegative = isNegative
 
     def get_operating_patches(self) -> List[uuid.UUID]:
         return list(self.patch_pauli_operator_map.keys())
@@ -129,8 +135,8 @@ class LogicalLatticeComputation:
                 ret[self.logical_qubit_uuid_map[qubit_idx]] = m.get_op(qubit_idx)
 
         if len(ret) == 1:
-            return SinglePatchMeasurement(next(iter(ret)), ret[next(iter(ret))])
-        return MultiBodyMeasurement(ret)
+            return SinglePatchMeasurement(next(iter(ret)), ret[next(iter(ret))], m.isNegative)
+        return MultiBodyMeasurement(ret, m.isNegative)
 
     def num_logical_qubits(self) -> int:
         return len(self.logical_qubit_uuid_map)

--- a/tests/logical_lattice_ops/logical_lattice_ops_test.py
+++ b/tests/logical_lattice_ops/logical_lattice_ops_test.py
@@ -96,7 +96,7 @@ def generate_tests_count_magic_states():
 
 def generate_tests_circuit_to_single_patch_measurement():
     m1 = Measurement.from_list([X], isNegative=False)
-    m2 = Measurement.from_list([I, Z], isNegative=False)
+    m2 = Measurement.from_list([I, Z], isNegative=True)
 
     c1 = PauliOpCircuit(1)
     c1.add_pauli_block(m1)
@@ -142,6 +142,7 @@ class TestLogicalLatticeComputation:
 
         assert isinstance(patch_measurement, SinglePatchMeasurement)
         assert [patch_measurement.op] == list(measurement.get_ops_map().values())
+        assert patch_measurement.isNegative == measurement.isNegative
 
     @pytest.mark.parametrize(
         "circuit, measurement", generate_tests_circuit_to_multi_body_measurements()
@@ -155,6 +156,7 @@ class TestLogicalLatticeComputation:
         assert list(patch_measurement.patch_pauli_operator_map.values()) == list(
             measurement.get_ops_map().values()
         )
+        assert patch_measurement.isNegative == measurement.isNegative
 
     def test_circuit_to_patch_measurement_type_error(self):
         circuit = PauliOpCircuit(1)


### PR DESCRIPTION
This includes changes to llops. Does not incorporate the changes in `simulation/`(currently interfering to #219!)
Partially fixes #164 