### PR TITLE
Remove Y's from all operators, not just pi/8 and measurements

### DIFF
--- a/debug/debug_litinski_y_op_removal_bug.py
+++ b/debug/debug_litinski_y_op_removal_bug.py
@@ -1,0 +1,67 @@
+from typing import List, Optional, Tuple
+
+import qiskit.visualization as qkvis
+from qiskit import circuit as qkcirc
+
+import lsqecc.logical_lattice_ops.logical_lattice_ops as llops
+import lsqecc.patches.lattice_surgery_computation_composer as lscc
+import lsqecc.pauli_rotations.segmented_qasm_parser as segmented_qasm_parser
+import lsqecc.simulation.logical_patch_state_simulation as lssim
+
+SAMPLE_CIRCUIT_1 = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+h q[0];
+cx q[0],q[1];
+h q[0];
+t q[1];
+s q[0];
+x q[0];
+"""
+
+SAMPLE_CIRCUIT_2 = """
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[2];
+
+h q[0];
+t q[0];
+h q[0];
+cx q[0],q[1];
+"""
+
+if __name__ == "__main__":
+
+    input_circuit = segmented_qasm_parser.parse_str(SAMPLE_CIRCUIT_2)
+
+    compilation_text = "Input Circuit:\n"
+
+    compilation_text += qkvis.circuit_drawer(
+        qkcirc.QuantumCircuit.from_qasm_str(SAMPLE_CIRCUIT_2)
+    ).single_string()
+
+    compilation_text += "\nCircuit as Pauli rotations:\n"
+    compilation_text += input_circuit.render_ascii()
+
+    # TODO add user flag
+    print("input")
+    print(input_circuit.render_ascii())
+    input_circuit = input_circuit.get_y_free_equivalent()
+    print("removed y")
+    print(input_circuit.render_ascii())
+    input_circuit.apply_transformation()
+    print("done litinski")
+    print(input_circuit.render_ascii())
+    input_circuit = input_circuit.get_y_free_equivalent()
+    print("removed y again")
+    print(input_circuit.render_ascii())
+
+    logical_computation = llops.LogicalLatticeComputation(input_circuit)
+    lsc = lscc.LatticeSurgeryComputation.make_computation_with_simulation(
+        logical_computation,
+        lscc.LayoutType.SimplePreDistilledStates
+    )
+
+    print(compilation_text)

--- a/src/lsqecc/pauli_rotations/circuit.py
+++ b/src/lsqecc/pauli_rotations/circuit.py
@@ -131,12 +131,7 @@ class PauliOpCircuit(object):
         y_free_circuit = PauliOpCircuit(self.qubit_num, self.name)
 
         for block in self.ops:
-            if isinstance(block, Measurement) or (
-                cast(PauliRotation, block).rotation_amount in {Fraction(1, 8), Fraction(-1, 8)}
-            ):
-                y_free_circuit.ops.extend(block.get_y_free_equivalent())
-            else:
-                y_free_circuit.add_pauli_block(copy.deepcopy(block))
+            y_free_circuit.ops.extend(block.get_y_free_equivalent())
 
         return y_free_circuit
 

--- a/src/lsqecc/pauli_rotations/rotation.py
+++ b/src/lsqecc/pauli_rotations/rotation.py
@@ -151,7 +151,6 @@ class PauliProductOperation(ABC):
             ]
         )
 
-    @abstractmethod
     def get_y_free_equivalent(self):
         """Return the equivalent of current block but without Y operator."""
         y_op_indices = list()
@@ -229,13 +228,6 @@ class PauliRotation(PauliProductOperation, coc.ConditionalOperation):
             r.change_single_op(i, op)
         return r
 
-    def get_y_free_equivalent(self) -> List["PauliRotation"]:
-        """Return the equivalent of current Pauli Rotation but without Y operator.
-        Supports all rotations.
-        """
-
-        return super().get_y_free_equivalent()
-
 
 class Measurement(PauliProductOperation, coc.ConditionalOperation):
     """Representing a Pauli Product Measurement Block"""
@@ -280,7 +272,3 @@ class Measurement(PauliProductOperation, coc.ConditionalOperation):
             m.change_single_op(i, op)
 
         return m
-
-    def get_y_free_equivalent(self) -> List[PauliProductOperation]:
-        """Return the equivalent of current Measurement block but without Y operator."""
-        return super().get_y_free_equivalent()

--- a/src/lsqecc/pauli_rotations/rotation.py
+++ b/src/lsqecc/pauli_rotations/rotation.py
@@ -186,6 +186,9 @@ class PauliProductOperation(ABC):
 
         return left_rotations + [y_free_block] + right_rotations
 
+    def has_y(self):
+        return any(op == PauliOperator.Y for op in self.ops_list)
+
 
 class PauliRotation(PauliProductOperation, coc.ConditionalOperation):
     """Class for representing a Pauli Product Rotation Block."""

--- a/tests/pauli_rotations/rotation_test.py
+++ b/tests/pauli_rotations/rotation_test.py
@@ -221,6 +221,19 @@ def test_cases_get_y_free_equivalent_measurements():
     return [case_1, case_2]
 
 
+@pytest.mark.parametrize(
+    "block, has_y",
+    [
+        (PauliRotation.from_list([I, X, Z], Fraction(1, 8)), False),
+        (PauliRotation.from_list([Y, X, Z], Fraction(1, 8)), True),
+        (Measurement.from_list([I, X, Z]), False),
+        (Measurement.from_list([Y, X, Z]), True),
+    ],
+)
+def test_has_y(block: PauliProductOperation, has_y: bool):
+    assert block.has_y() == has_y
+
+
 class TestMeasurement:
     """Tests for Measurement class"""
 


### PR DESCRIPTION
As discussed in [this conversation](https://github.com/latticesurgery-com/lattice-surgery-compiler/pull/185/files/a80dc0ff52646d8595ada1f0c409b64698646de1#r767273177) there is nothing special about the pi/8 angle and we can remove Y operators from any angle.

The fact we were not running y removal on pi/4 was causing problems in circuits such as the one in the debug file, because Y operators were getting to the patch level.