### PR TITLE
Add python 3.10 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Works on my machine. @alexnguyenn should we drop 3.10? I was kind of glad we had it when we experimented wit pypy ... but that was a failure eventually.