### PR TITLE
Replace UUIDs with random bytes

### DIFF
--- a/src/lsqecc/patches/lattice_surgery_computation_composer.py
+++ b/src/lsqecc/patches/lattice_surgery_computation_composer.py
@@ -17,13 +17,13 @@
 
 import copy
 import enum
-import uuid
 from typing import Dict, List, Optional, Tuple, cast
 
 import lsqecc.logical_lattice_ops.logical_lattice_ops as llops
 import lsqecc.patches.patches as patches
 import lsqecc.simulation.logical_patch_state_simulation as lps
 import lsqecc.simulation.qubit_state as qs
+from lsqecc.utils import PatchId
 
 from . import ancilla_region_routing as ancilla_region_routing
 
@@ -252,10 +252,10 @@ class LatticeSurgeryComputation:
 
         return LatticeSurgeryComputationSliceContextManager(self.composer)
 
-    def find_cell_by_qubit_uuid(self, qubit_uuid: uuid.UUID) -> Tuple[int, int]:
+    def find_cell_by_qubit_uuid(self, qubit_uuid: PatchId) -> Tuple[int, int]:
         return self.composer.lattice().getPatchByUuid(qubit_uuid).getRepresentative()
 
-    def bind_magic_state(self, patch_uuid: uuid.UUID) -> Optional[patches.Patch]:
+    def bind_magic_state(self, patch_uuid: PatchId) -> Optional[patches.Patch]:
         if len(self.magic_state_queue) == 0:
             return None
         cell = self.magic_state_queue[0]
@@ -283,7 +283,7 @@ class LatticeSurgeryComputationComposer:
         self.lattice().patches.append(patch)
 
     def addSquareAncilla(
-        self, patch_state: qs.QubitState, patch_uuid: Optional[uuid.UUID] = None
+        self, patch_state: qs.QubitState, patch_uuid: Optional[PatchId] = None
     ) -> Optional[Tuple[int, int]]:
         cell = self.getAncillaLocation()
         if cell is None:
@@ -378,10 +378,10 @@ class LatticeSurgeryComputationComposer:
     def getSlices(self) -> List[patches.Lattice]:
         return self.qubit_patch_slices
 
-    def get_patch_representative(self, quuid: uuid.UUID) -> Tuple[int, int]:
+    def get_patch_representative(self, quuid: PatchId) -> Tuple[int, int]:
         return self.get_patch(quuid).getRepresentative()
 
-    def get_patch(self, quuid: uuid.UUID) -> patches.Patch:
+    def get_patch(self, quuid: PatchId) -> patches.Patch:
         p = self.lattice().getPatchByUuid(quuid)
         assert p is not None
         return p

--- a/src/lsqecc/patches/patches.py
+++ b/src/lsqecc/patches/patches.py
@@ -18,11 +18,11 @@
 from __future__ import annotations
 
 import itertools
-import uuid
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from lsqecc.pauli_rotations import PauliOperator
+from lsqecc.utils import PatchId
 
 if TYPE_CHECKING:
     from lsqecc.logical_lattice_ops.logical_lattice_ops import LogicalLatticeOperation
@@ -115,7 +115,7 @@ class Patch:
         state: Optional[QubitState],
         cells: List[Tuple[int, int]],
         edges: List[Edge],
-        qubit_uuid: Optional[uuid.UUID] = None,
+        qubit_uuid: Optional[PatchId] = None,
     ):
         self.patch_type = patch_type
         self.cells = cells
@@ -141,7 +141,7 @@ class Patch:
     def getCoordList(self, coord_type: CoordType) -> List[int]:
         return list(map(lambda cell: cell[coord_type.value], self.cells))
 
-    def set_uuid(self, patch_uuid: uuid.UUID):
+    def set_uuid(self, patch_uuid: PatchId):
         self.patch_uuid = patch_uuid
 
 
@@ -190,7 +190,7 @@ class Lattice:
         maybe_patch = self.getPatchOfCell(cell)
         return maybe_patch.patch_type if maybe_patch is not None else None
 
-    def getPatchByUuid(self, patch_uuid: uuid.UUID) -> Optional[Patch]:
+    def getPatchByUuid(self, patch_uuid: PatchId) -> Optional[Patch]:
         for p in self.patches:
             if p.patch_uuid is not None and p.patch_uuid == patch_uuid:
                 return p

--- a/src/lsqecc/utils.py
+++ b/src/lsqecc/utils.py
@@ -16,6 +16,7 @@
 # USA
 
 import math
+import random
 from dataclasses import asdict
 from fractions import Fraction
 
@@ -69,3 +70,12 @@ def dataclass_render_ascii(self) -> str:
     return "Estimated resources needed for computation:\n" + "\n".join(
         [f"{name.replace('_',' ')}: {value}" for name, value in asdict(self).items()]
     )
+
+
+PatchId = bytes
+
+_patch_id_counter = 0
+
+
+def get_new_patch_id():
+    return random.randbytes(20)


### PR DESCRIPTION
An idea to improve performance, unfortunately not significant. Opens the possibility of very rare id collision and printing might not always be easy, so need to think about it a bit more.

Running the gigant qft benchmark. Before:
```
num_qubits=20
Generating qft with AO-Benchmark
Time to generate: 0.01850271224975586
Generated:  PauliOpCircuit : 20 qubit(s), 1200 block(s)
Approximate all gates with pi/2, pi/4, pi/8 rotations
Generated (took 50.95249819755554:  PauliOpCircuit : 20 qubit(s), 953005 block(s)
Make logical lattice ops
Generated (took 136.13677263259888s):  PauliOpCircuit : 20 qubit(s), 953005 block(s)
```

After:
```
num_qubits=20
Generating qft with AO-Benchmark
Time to generate: 0.018328428268432617
Generated:  PauliOpCircuit : 20 qubit(s), 1200 block(s)
Approximate all gates with pi/2, pi/4, pi/8 rotations
Generated (took 48.364278078079224:  PauliOpCircuit : 20 qubit(s), 953005 block(s)
Make logical lattice ops
Generated (took 116.9310896396637s):  PauliOpCircuit : 20 qubit(s), 953005 block(s)
```