### PR TITLE
Make lsqecc pep 561 compliant

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/lsqecc/py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ line-length = 100
 
 [tool.mypy]
 ignore_missing_imports = true
-namespace_packages = true
-explicit_package_bases = true
-mypy_path = "src"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ line-length = 100
 
 [tool.mypy]
 ignore_missing_imports = true
+namespace_packages = true
+explicit_package_bases = true
+mypy_path = "src"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,10 @@ install_requires =
     igraph>=0.9.8, <0.9.10
 package_dir = 
     =src
+# Allows to avoid issues with installing package in editable mode.
+# See also: https://github.com/python/mypy/issues/7508#issuecomment-531965557
 zip_safe = False
+# Require for compliance with PEP 561
 include_package_data = True
     
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,8 +23,7 @@ project_urls =
     Tracker = https://github.com/latticesurgery-com/lattice-surgery-compiler/issues
 
 [options]
-packages = 
-    lsqecc
+packages = find:
 python_requires = >=3.7
 install_requires =
     qiskit>=0.24.0, <0.35.0
@@ -32,6 +31,11 @@ install_requires =
     igraph>=0.9.8, <0.9.10
 package_dir = 
     =src
+zip_safe = False
+include_package_data = True
+    
+[options.packages.find]
+where = src
 
 [options.extras_require]
 latex =


### PR DESCRIPTION
Imagine some other projects wants to use `lsqecc`. They can use it, but unfortunately the won't be able to run mypy against any imports from `lsqecc`, unless package is [PEP 561 compliant](https://www.python.org/dev/peps/pep-0561/).

This PR adds the components necessary to make it works.

It also solves a couple of other issues:
1. Due to the configuration in `setup.cfg`, when I was building `lsqecc` locally and trying to install with wheel, I noticed that the package is empty. Changing to `packages = find:` in `setup.cfg` solved this issue.
2. I've also added `zip_safe=False`, as it's known to interfere with editable installations (see [here](https://github.com/python/mypy/issues/7508#issuecomment-531965557)
3. `namespace_packages=true`  – this will allow to avoid `__init__.py` at all the levels. I'm not sure if this change is actually desirable, please let me know.
4. `explicit_package_bases=true` allows to avoid some issues with mypy configuration in the future.

If you want I can add inline comments to those config files explaining the reason behind them.