### PR TITLE
LS Instruction short-hand codes

### DIFF
--- a/src/lsqecc/ls_instructions/ls_instructions.py
+++ b/src/lsqecc/ls_instructions/ls_instructions.py
@@ -37,19 +37,12 @@ class Init(LSInstruction):
 
 
 @dataclass
-class RequestMagicState(LSInstruction):
+class MeasureSinglePatch(LSInstruction):
     patch_id: PatchId = -1
+    op: PauliOperator = PauliOperator.Z
 
     def __repr__(self):
-        return f"{type(self).__name__} {self.patch_id}"
-
-
-@dataclass
-class RequestYState(LSInstruction):
-    patch_id: PatchId = -1
-
-    def __repr__(self):
-        return f"{type(self).__name__}  {self.patch_id}"
+        return f"{type(self).__name__} {self.patch_id} {self.op}"
 
 
 @dataclass
@@ -65,12 +58,11 @@ class MultiBodyMeasure(LSInstruction):
 
 
 @dataclass
-class MeasureSinglePatch(LSInstruction):
+class RequestMagicState(LSInstruction):
     patch_id: PatchId = -1
-    op: PauliOperator = PauliOperator.Z
 
     def __repr__(self):
-        return f"{type(self).__name__} {self.patch_id} {self.op}"
+        return f"{type(self).__name__} {self.patch_id}"
 
 
 @dataclass
@@ -83,6 +75,14 @@ class LogicalPauli(LSInstruction):
 
 
 @dataclass
+class HGate(LSInstruction):
+    patch_id: PatchId = -1
+
+    def __repr__(self):
+        return f"{type(self).__name__} {self.patch_id}"
+
+
+@dataclass
 class SGate(LSInstruction):
     patch_id: PatchId = -1
 
@@ -91,8 +91,8 @@ class SGate(LSInstruction):
 
 
 @dataclass
-class HGate(LSInstruction):
+class RequestYState(LSInstruction):
     patch_id: PatchId = -1
 
     def __repr__(self):
-        return f"{type(self).__name__} {self.patch_id}"
+        return f"{type(self).__name__}  {self.patch_id}"

--- a/src/lsqecc/ls_instructions/shorthand_file_writer.py
+++ b/src/lsqecc/ls_instructions/shorthand_file_writer.py
@@ -8,7 +8,7 @@ class ShorthandFileWriter:
     def __init__(self, output_file: TextIO):
         self.output_file = output_file
 
-    def write_instructions(self, instruction: lsi.LSInstruction):
+    def write_instruction(self, instruction: lsi.LSInstruction):
         if isinstance(instruction, lsi.DeclareLogicalQubitPatches):
             self.output_file.write(repr(instruction))
         elif isinstance(instruction, lsi.Init):

--- a/src/lsqecc/ls_instructions/shorthand_file_writer.py
+++ b/src/lsqecc/ls_instructions/shorthand_file_writer.py
@@ -1,0 +1,59 @@
+from typing import TextIO
+
+import lsqecc.simulation.qubit_state as qs
+from lsqecc.ls_instructions import ls_instructions as lsi
+
+
+class ShorthandFileWriter:
+    def __init__(self, output_file: TextIO):
+        self.output_file = output_file
+
+    def write_instructions(self, instruction: lsi.LSInstruction):
+        if isinstance(instruction, lsi.DeclareLogicalQubitPatches):
+            self.output_file.write(repr(instruction))
+        elif isinstance(instruction, lsi.Init):
+            self.output_file.write("0 ")
+            self.output_file.write(str(instruction.patch_id))
+            self.output_file.write(" ")
+            self.output_file.write(ShorthandFileWriter.shorthand_state(instruction.state))
+        elif isinstance(instruction, lsi.MeasureSinglePatch):
+            self.output_file.write("1 ")
+            self.output_file.write(str(instruction.patch_id))
+            self.output_file.write(" ")
+            self.output_file.write(str(instruction.op))
+        elif isinstance(instruction, lsi.MultiBodyMeasure):
+            self.output_file.write("2 ")
+            self.output_file.write(
+                ",".join(
+                    str(patch_id) + ":" + str(op)
+                    for patch_id, op in instruction.patch_pauli_map.items()
+                )
+            )
+        elif isinstance(instruction, lsi.RequestMagicState):
+            self.output_file.write("3 ")
+            self.output_file.write(str(instruction.patch_id))
+        elif isinstance(instruction, lsi.LogicalPauli):
+            self.output_file.write("4 ")
+            self.output_file.write(str(instruction.patch_id))
+            self.output_file.write(" ")
+            self.output_file.write(str(instruction.op))
+        elif isinstance(instruction, lsi.HGate):
+            self.output_file.write("5 ")
+            self.output_file.write(str(instruction.patch_id))
+        elif isinstance(instruction, lsi.SGate):
+            self.output_file.write("6 ")
+            self.output_file.write(str(instruction.patch_id))
+        elif isinstance(instruction, lsi.RequestYState):
+            self.output_file.write("7 ")
+            self.output_file.write(str(instruction.patch_id))
+        else:
+            raise NotImplementedError(f"No shorthand for instruction: {instruction}")
+        self.output_file.write("\n")
+
+    @staticmethod
+    def shorthand_state(symbolic_state: qs.QubitState) -> str:
+        if symbolic_state == qs.DefaultSymbolicStates.Zero:
+            return "0"
+        if symbolic_state == qs.DefaultSymbolicStates.Plus:
+            return "+"
+        return symbolic_state.ket_repr()

--- a/tests/ls_instructions/test_shorthand_file_writer.py
+++ b/tests/ls_instructions/test_shorthand_file_writer.py
@@ -1,0 +1,50 @@
+from typing import TextIO, cast
+
+import pytest
+
+import lsqecc.simulation.qubit_state as qs
+from lsqecc.ls_instructions import ls_instructions as lsi
+from lsqecc.ls_instructions.shorthand_file_writer import ShorthandFileWriter
+from lsqecc.pauli_rotations import PauliOperator
+
+
+class MockFile:
+    def __init__(self):
+        self.content = ""
+
+    def write(self, s: str):
+        self.content += s
+
+
+@pytest.mark.parametrize(
+    "instruction, expected_output",
+    [
+        (lsi.DeclareLogicalQubitPatches([0, 1, 2, 100]), "DeclareLogicalQubitPatches 0,1,2,100"),
+        (lsi.Init(patch_id=101, state=qs.DefaultSymbolicStates.Zero), "0 101 0"),
+        (lsi.Init(patch_id=102, state=qs.DefaultSymbolicStates.Plus), "0 102 +"),
+        (lsi.Init(patch_id=102, state=qs.DefaultSymbolicStates.UnknownState), "0 102 |?>"),
+        (lsi.MeasureSinglePatch(patch_id=103, op=PauliOperator.X), "1 103 X"),
+        (lsi.MeasureSinglePatch(patch_id=104, op=PauliOperator.Z), "1 104 Z"),
+        (
+            lsi.MultiBodyMeasure(patch_pauli_map={105: PauliOperator.X, 106: PauliOperator.Z}),
+            "2 105:X,106:Z",
+        ),
+        (
+            lsi.MultiBodyMeasure(
+                patch_pauli_map={107: PauliOperator.X, 108: PauliOperator.Z, 109: PauliOperator.Z}
+            ),
+            "2 107:X,108:Z,109:Z",
+        ),
+        (lsi.RequestMagicState(patch_id=110), "3 110"),
+        (lsi.LogicalPauli(patch_id=111, op=PauliOperator.X), "4 111 X"),
+        (lsi.LogicalPauli(patch_id=112, op=PauliOperator.Z), "4 112 Z"),
+        (lsi.HGate(patch_id=113), "5 113"),
+        (lsi.SGate(patch_id=114), "6 114"),
+        (lsi.RequestYState(patch_id=115), "7 115"),
+    ],
+)
+def test_write_instruction(instruction, expected_output):
+    mock_file = MockFile()
+    writer = ShorthandFileWriter(cast(TextIO, mock_file))
+    writer.write_instruction(instruction)
+    assert mock_file.content == expected_output + "\n"


### PR DESCRIPTION
Adds a class to print [LS-Instructions](https://github.com/latticesurgery-com/lattice-surgery-compiler/issues/246) with short-hand codes instead of the full opcode, i.e:
```
RequestMagicState => 1
MultiBodyMeasure => 2
MeasureSinglePatch => 3
...
```

Takes the file size of LS-Instruction files down drastically since most of the file size was taken up by the long opcodes.

##### Benchmark
QFT 100:
```
Generate LS Instructions
Generated: 39101029 lines, 761581272 chars for full length mnemonics and 346705421 for shorthand LS
```
that is 761.6 MB vs 346.7 MB