### PR TITLE
Adds docstrings for Orientation class

### DIFF
--- a/src/lsqecc/patches/patches.py
+++ b/src/lsqecc/patches/patches.py
@@ -30,9 +30,20 @@ if TYPE_CHECKING:
 
 
 class Orientation(Enum):
+    """Enum for representing the sides of a Patch.
+    Mainly used to determine which side of a Patch an Edge lies on.
+    """
+
+    """Top side of the patch."""
     Top = "Top"
+
+    """Bottom side of the patch."""
     Bottom = "Bottom"
+
+    """Left side of the patch."""
     Left = "Left"
+
+    """Right side of the patch."""
     Right = "Right"
 
     @staticmethod

--- a/src/lsqecc/patches/patches.py
+++ b/src/lsqecc/patches/patches.py
@@ -34,17 +34,17 @@ class Orientation(Enum):
     Mainly used to determine which side of a Patch an Edge lies on.
     """
 
-    """Top side of the patch."""
     Top = "Top"
+    """Top side of the patch."""
 
-    """Bottom side of the patch."""
     Bottom = "Bottom"
+    """Bottom side of the patch."""
 
-    """Left side of the patch."""
     Left = "Left"
+    """Left side of the patch."""
 
-    """Right side of the patch."""
     Right = "Right"
+    """Right side of the patch."""
 
     @staticmethod
     def get_graph_edge(edge: Edge) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:


### PR DESCRIPTION
Note: Docstrings had to be added below each enum value to make Sphinx happy. Putting the docstring above is possible if I use `#:`, but I wanted to stay consistent.