### PR TITLE
Adds docstrings to EdgeType class

### DIFF
--- a/src/lsqecc/patches/patches.py
+++ b/src/lsqecc/patches/patches.py
@@ -49,6 +49,12 @@ class Orientation(Enum):
 
 
 class EdgeType(Enum):
+    """Enum for representing what an Edge looks like and what type of operation it encodes.
+    When representing Pauli operators, an Edge is (solid or dashed) and (stitched or unstitched).
+    Alternatively, it can represent the border of joining ancilla patches.
+    Different Pauli operators are mapped to different EdgeType values: X is dashed, and Z is solid.
+    """
+
     Solid = "Solid"
     SolidStiched = "SolidStiched"
     Dashed = "Dashed"

--- a/src/lsqecc/patches/patches.py
+++ b/src/lsqecc/patches/patches.py
@@ -51,15 +51,24 @@ class Orientation(Enum):
 class EdgeType(Enum):
     """Enum for representing what an Edge looks like and what type of operation it encodes.
     When representing Pauli operators, an Edge is (solid or dashed) and (stitched or unstitched).
-    Alternatively, it can represent the border of joining ancilla patches.
+    Alternatively, it can represent the border of joining ancilla Patches.
     Different Pauli operators are mapped to different EdgeType values: X is dashed, and Z is solid.
     """
 
     Solid = "Solid"
+    """The Edge is Solid and not Stitched, and it encodes the Pauli Z operation."""
+
     SolidStiched = "SolidStiched"
+    """The Edge is Solid and Stitched, and it encodes the Pauli Z operation."""
+
     Dashed = "Dashed"
+    """The Edge is Solid and not Stitched, and encodes the Pauli X operation."""
+
     DashedStiched = "DashedStiched"
+    """The Edge is Solid and Stitched and encodes the Pauli X operation."""
+
     AncillaJoin = "AncillaJoin"
+    """The Edge represents a join between ancilla Patches."""
 
     def stitched_type(self):
         if self == EdgeType.Solid:

--- a/src/lsqecc/patches/patches.py
+++ b/src/lsqecc/patches/patches.py
@@ -71,6 +71,7 @@ class EdgeType(Enum):
     """The Edge represents a join between ancilla Patches."""
 
     def stitched_type(self):
+        """Returns stitched version of current EdgeType value, or self if already stitched."""
         if self == EdgeType.Solid:
             return EdgeType.SolidStiched
         if self == EdgeType.Dashed:
@@ -78,6 +79,7 @@ class EdgeType(Enum):
         return self
 
     def unstitched_type(self):
+        """Returns unstitched version of current EdgeType value, or self if already unstitched."""
         if self == EdgeType.SolidStiched:
             return EdgeType.Solid
         if self == EdgeType.DashedStiched:


### PR DESCRIPTION
I'm not exactly sure:

- if the stitched EdgeTypes are the same Pauli operator, and
- what the AncillaJoin enum value means-- if what I wrote is wrong, feel free to let me know and I can rewrite it.

Note: Docstrings had to be added below each enum value to make Sphinx happy. Putting the docstring above is possible if I use `#:`, but I wanted to stay consistent.