### PR TITLE
Adds docstrings for the PatchType class

### DIFF
--- a/src/lsqecc/patches/patches.py
+++ b/src/lsqecc/patches/patches.py
@@ -80,8 +80,13 @@ class PatchType(Enum):
     """Enum for classifying what a patch represents."""
 
     Qubit = "Qubit"
+    """Patch represents a logical qubit."""
+
     DistillationQubit = "DistillationQubit"
+    """Patch represents a qubit used for entanglement distillation."""
+
     Ancilla = "Ancilla"
+    """Patch represents ancilla qubits."""
 
 
 class Edge:

--- a/src/lsqecc/patches/patches.py
+++ b/src/lsqecc/patches/patches.py
@@ -77,6 +77,8 @@ PAULI_OPERATOR_TO_EDGE_MAP: Dict[PauliOperator, EdgeType] = {
 
 
 class PatchType(Enum):
+    """Enum for classifying what a patch represents."""
+
     Qubit = "Qubit"
     DistillationQubit = "DistillationQubit"
     Ancilla = "Ancilla"


### PR DESCRIPTION
Note: Docstrings had to be added below each enum value to make Sphinx happy. Putting the docstring above is possible if I use `#:`, but I wanted to stay consistent.