### PR TITLE
Adds the docs page docs/api/patches

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -5,6 +5,6 @@ This section is still under active development
 ```
 
 ```{toctree}
-
+patches
 pauli_rotations
 ```

--- a/docs/source/api/patches.md
+++ b/docs/source/api/patches.md
@@ -5,6 +5,12 @@ This section is still under active development
 ```
 
 ```{eval-rst}
+.. autoclass:: lsqecc.patches.patches.Edge
+    :show-inheritance:
+    :members:
+```
+
+```{eval-rst}
 .. autoclass:: lsqecc.patches.patches.Orientation
     :show-inheritance:
     :members:

--- a/docs/source/api/patches.md
+++ b/docs/source/api/patches.md
@@ -1,0 +1,12 @@
+# patches
+
+```{note}
+This section is still under active development
+```
+
+```{eval-rst}
+.. autoclass:: lsqecc.patches.patches.Orientation
+    :show-inheritance:
+    :members:
+    :member-order: bysource
+```

--- a/docs/source/api/patches.md
+++ b/docs/source/api/patches.md
@@ -16,3 +16,9 @@ This section is still under active development
     :show-inheritance:
     :members:
 ```
+
+```{eval-rst}
+.. autoclass:: lsqecc.patches.patches.PatchType
+    :show-inheritance:
+    :members:
+```

--- a/docs/source/api/patches.md
+++ b/docs/source/api/patches.md
@@ -10,3 +10,9 @@ This section is still under active development
     :members:
     :member-order: bysource
 ```
+
+```{eval-rst}
+.. autoclass:: lsqecc.patches.patches.EdgeType
+    :show-inheritance:
+    :members:
+```


### PR DESCRIPTION
This PR is purely for creating and updating the `docs/api/patches` page, but the docs page will be empty until the PRs with class docstrings are merged in.

This is separate since updating `docs/sources/api/patches.md` in each PR that adds a class docstring would create a merge conflict.